### PR TITLE
Add the skeleton of the test suite using `tact-jetton`

### DIFF
--- a/tests/ProofOfCapital.spec.ts
+++ b/tests/ProofOfCapital.spec.ts
@@ -1,0 +1,381 @@
+import { Blockchain, internal, SandboxContract, TreasuryContract } from '@ton/sandbox';
+import { beginCell, toNano, fromNano, Transaction, Address, ExternalAddress } from '@ton/core';
+import { ProofOfCapital } from '../wrappers/ProofOfCapital';
+import { JettonUpdateContent } from '../wrappers/TestJetton_JettonMinter';
+import { ExtendedJettonMinter } from '../wrappers/ExtendedJettonMinter';
+import { ExtendedJettonWallet } from '../wrappers/ExtendedJettonWallet';
+import { flattenTransaction } from '@ton/test-utils';
+import '@ton/test-utils';
+
+// TODO: Initialize the contract without the Jetton collateral and test its
+//       functionality. It could be done in the second test file for convinience.
+//
+// TODO: Check out-of-gas issues in `receive()`. We are interested in these formulas:
+//       https://github.com/proof-of-capital/TON/blob/137d44bbc649745f8cff864c8cad9db47bd70f26/contracts/proof_of_capital.tact#L605.
+//       The goal there is to set different state values (e.g.
+//       self.comission, self.quantityJettonsPerLevel) and different message
+//       values in order to test if it works.
+//
+// TODO: Test various functions involving the `isInitialized` and `isActive`
+//       conditions. The first condition could be checked in the initialization
+//       of the test suite, before sending the `TakeWalletAddress` message.
+//
+// TODO: Test the oldContractAddress usage scenarios.
+//
+// TODO: Test the migration process:
+//       1. Deploy two PoC contracts
+//       2. Add some collateral and issues tokens on the first one
+//       3. Freeze it, deactivate, and move tokens to the second one
+//       4. Ensure the offsets and steps on both contracts are equal
+
+// https://github.com/ton-org/sandbox/blob/24ad00977d3abb99ee027149acee1ab11a162bab/src/utils/prettyLogTransaction.ts#L5
+export type AddressMapFunc = (address: Address | ExternalAddress | null | undefined) => string | null | undefined;
+
+// Initial jettons balance
+const JETTONS_BALANCE = 10_000_000_000n;
+
+/**
+ * A helper function to access the jetton wallet from the given address.
+ */
+type JettonWalletCaller = (address: Address) => Promise<SandboxContract<ExtendedJettonWallet>>;
+
+describe.each([false, true])('ProofOfCapital (JETTON_COLLATERAL=%s)', (JETTON_COLLATERAL) => {
+    let blockchain: Blockchain;
+    let poc: SandboxContract<ProofOfCapital>;
+    let pocDeployer: SandboxContract<TreasuryContract>;
+    let marketMaker: SandboxContract<TreasuryContract>;
+    let launchMinter: SandboxContract<ExtendedJettonMinter>;
+    let launchDeployer: SandboxContract<TreasuryContract>;
+    let launchDeployerWallet: SandboxContract<ExtendedJettonWallet>;
+    let launchPocWallet: SandboxContract<ExtendedJettonWallet>;
+    let launchUserWallet: JettonWalletCaller;
+    let collateralMinter: SandboxContract<ExtendedJettonMinter>;
+    let collateralDeployer: SandboxContract<TreasuryContract>;
+    let collateralDeployerWallet: SandboxContract<ExtendedJettonWallet>;
+    let collateralPocWallet: SandboxContract<ExtendedJettonWallet>;
+    let collateralUserWallet: JettonWalletCaller;
+
+    beforeAll(async () => {
+        blockchain = await Blockchain.create();
+        // Initialize jettons used by the contract
+        launchDeployer = await blockchain.treasury('launchDeployer');
+        launchMinter = await deployMinter(launchDeployer);
+        [launchDeployerWallet, launchUserWallet] = await deployWallet(launchDeployer, launchMinter);
+        if (JETTON_COLLATERAL) {
+            // Collater jetton is optional. It could be used instead of TON if
+            // the PoC contract is configured that way.
+            collateralDeployer = await blockchain.treasury('jettonCollateralDeployer');
+            collateralMinter = await deployMinter(collateralDeployer);
+            [collateralDeployerWallet, collateralUserWallet] = await deployWallet(collateralDeployer, collateralMinter);
+        }
+        // Initialize the poc contract
+        marketMaker = await blockchain.treasury('marketMaker');
+        pocDeployer = await blockchain.treasury('deployer');
+        poc = blockchain.openContract(
+            await ProofOfCapital.fromInit(
+                /*id=*/ 0n,
+                /*owner=*/ pocDeployer.address,
+                /*marketMakerAddress=*/ marketMaker.address,
+                /*launchMasterAddress=*/ launchMinter.address,
+                /*returnWalletAddress=*/ pocDeployer.address,
+                /*royaltyWalletAddress=*/ pocDeployer.address,
+                /*lockEndTime=*/ BigInt(Math.floor(Date.now() / 1000)),
+                /*initialPricePerToken=*/ 15000n,
+                /*firstLevelJettonQuantity=*/ toNano(5000000n),
+                /*priceIncrementMultiplier=*/ 50n,
+                /*levelIncreaseMultiplier=*/ 20n,
+                /*trendChangeStep=*/ 20n,
+                /*levelDecreaseMultiplierafterTrend=*/ 9n,
+                /*profitPercentage=*/ 100n /*10%*/,
+                /*offsetJettons=*/ toNano(15000n),
+                /*controlPeriod=*/ 60n,
+                /*jettonCollateral=*/ JETTON_COLLATERAL,
+                /*jettonCollateralMasterAddress=*/ JETTON_COLLATERAL ? collateralMinter.address : pocDeployer.address,
+                /*royaltyProfitPercent=*/ 200n,
+                /*coefficientProfit=*/ 200n,
+                /*jettonDecimals=*/ toNano(1n),
+            ),
+        );
+        const deployResult = await poc.send(
+            pocDeployer.getSender(),
+            { value: toNano('0.1') },
+            { $$type: 'Deploy', queryId: 0n },
+        );
+        expect(deployResult.transactions).toHaveTransaction({
+            from: pocDeployer.address,
+            to: poc.address,
+            deploy: true,
+            success: true,
+        });
+
+        // Save jetton wallets owned by the PoC contract
+        launchPocWallet = await launchUserWallet(poc.address);
+        expect(launchPocWallet.address.toString()).toBe((await poc.getJettonWalletAddress()).toString());
+        if (JETTON_COLLATERAL) {
+            collateralPocWallet = await collateralUserWallet(poc.address);
+            expect(collateralPocWallet.address.toString()).toBe(
+                (await poc.getContractJettonCollateralWalletAddress()).toString(),
+            );
+        }
+    });
+
+    async function deployMinter(
+        deployer: SandboxContract<TreasuryContract>,
+    ): Promise<SandboxContract<ExtendedJettonMinter>> {
+        const defaultContent = beginCell().endCell();
+        const msg: JettonUpdateContent = {
+            $$type: 'JettonUpdateContent',
+            queryId: 0n,
+            content: defaultContent,
+        };
+        const minter = blockchain.openContract(
+            await ExtendedJettonMinter.fromInit(0n, deployer.address, defaultContent),
+        );
+        const result = await minter.send(deployer.getSender(), { value: toNano('0.1') }, msg);
+        expect(result.transactions).toHaveTransaction({
+            from: deployer.address,
+            to: minter.address,
+            deploy: true,
+            success: true,
+        });
+        return minter;
+    }
+
+    async function deployWallet(
+        deployer: SandboxContract<TreasuryContract>,
+        minter: SandboxContract<ExtendedJettonMinter>,
+    ): Promise<[SandboxContract<ExtendedJettonWallet>, JettonWalletCaller]> {
+        const wallet = blockchain.openContract(
+            await ExtendedJettonWallet.fromInit(deployer.address, minter.address, 0n),
+        );
+        const userWallet = async (address: Address) => {
+            return blockchain.openContract(new ExtendedJettonWallet(await minter.getGetWalletAddress(address)));
+        };
+        return [wallet, userWallet];
+    }
+
+    /**
+     * Executes the mint functions of the jetton called by its master.
+     * This results in minting `jettons` to its wallet.
+     */
+    async function mintJettons(
+        jettonDeployer: SandboxContract<TreasuryContract>,
+        master: SandboxContract<ExtendedJettonMinter>,
+        deployerWallet: SandboxContract<ExtendedJettonWallet>,
+        jettonsMintAmount: bigint,
+    ) {
+        const supplyBefore = await master.getTotalSupply();
+        const result = await master.sendMint(
+            jettonDeployer.getSender(),
+            jettonDeployer.address,
+            jettonsMintAmount,
+            toNano('0.05'),
+            toNano('1'),
+        );
+        expect(result.transactions).toHaveTransaction({
+            from: master.address,
+            to: deployerWallet.address,
+            deploy: true,
+        });
+        const supplyAfter = await master.getTotalSupply();
+        expect(supplyBefore + jettonsMintAmount === supplyAfter).toBe(true);
+    }
+
+    /**
+     * Transfers jettons from the sender's wallet to the wallet owned by `receiver`.
+     *
+     * The total supply of minted jettons (see `mintJettons`) must be sufficient,
+     * as well as the sender's jetton balance.
+     *
+     * @param receiver The address of the jetton receiver. This must be the exact
+     * contract or user address (NOT the address of their jetton wallet).
+     */
+    async function transferJettons(
+        senderWalletOwner: SandboxContract<TreasuryContract>,
+        senderWallet: SandboxContract<ExtendedJettonWallet>,
+        receiver: Address,
+        jettonsAmount: bigint,
+    ) {
+        const senderBalanceBefore = await senderWallet.getJettonBalance();
+        expect(senderBalanceBefore).toBeGreaterThanOrEqual(jettonsAmount);
+        const receiverWallet = await launchUserWallet(receiver);
+        const receiverBalanceBefore = await receiverWallet.getJettonBalance();
+        await senderWallet.sendTransfer(
+            senderWalletOwner.getSender(),
+            toNano('0.5'),
+            jettonsAmount,
+            receiver,
+            senderWalletOwner.address,
+            null,
+            0n,
+            null,
+        );
+        const senderBalanceAfter = await senderWallet.getJettonBalance();
+        const receiverBalanceAfter = await receiverWallet.getJettonBalance();
+        expect(senderBalanceBefore - jettonsAmount).toBe(senderBalanceAfter);
+        expect(receiverBalanceBefore + jettonsAmount).toBe(receiverBalanceAfter);
+    }
+
+    /**
+     * Implements the same logic as `transferJettons`, but uses the PoC contract
+     * instead of the TEP74 compatible jetton wallet.
+     */
+    async function transferPocJettons(
+        senderWalletOwner: SandboxContract<TreasuryContract>,
+        senderWallet: SandboxContract<ExtendedJettonWallet>,
+        jettonsAmount: bigint,
+    ) {
+        const senderBalanceBefore = await senderWallet.getJettonBalance();
+        expect(senderBalanceBefore).toBeGreaterThanOrEqual(jettonsAmount);
+        const pocBalanceBefore = await poc.getJettonBalance();
+        const result = await senderWallet.sendTransfer(
+            senderWalletOwner.getSender(),
+            toNano('0.5'),
+            jettonsAmount,
+            poc.address,
+            senderWalletOwner.address,
+            null,
+            0n,
+            null,
+        );
+        console.log(ppTxes(result.transactions));
+        const senderBalanceAfter = await senderWallet.getJettonBalance();
+        const pocBalanceAfter = await poc.getJettonBalance();
+        expect(senderBalanceBefore - jettonsAmount).toBe(senderBalanceAfter);
+        expect(pocBalanceBefore + jettonsAmount).toBe(pocBalanceAfter);
+    }
+
+    // ----------------------------------------------------
+    // Tests
+    // ----------------------------------------------------
+
+    it('should deploy', async () => {
+        expect(poc).toBeDefined();
+        expect(launchMinter).toBeDefined();
+        expect(launchDeployerWallet).toBeDefined();
+        expect(launchUserWallet).toBeDefined();
+        expect(launchPocWallet).toBeDefined();
+        await mintJettons(launchDeployer, launchMinter, launchDeployerWallet, JETTONS_BALANCE);
+        if (JETTON_COLLATERAL) {
+            expect(collateralMinter).toBeDefined();
+            expect(collateralDeployerWallet).toBeDefined();
+            expect(collateralUserWallet).toBeDefined();
+            expect(collateralPocWallet).toBeDefined();
+            await mintJettons(collateralDeployer, collateralMinter, collateralDeployerWallet, JETTONS_BALANCE);
+        }
+    });
+
+    it('should accept TONs from owner via receive()', async () => {
+        if (!JETTON_COLLATERAL) return;
+        const sentTons = toNano('10');
+        const expectedCommission = toNano('0.1');
+        const tonBalanceBefore = await poc.getBalance();
+        await poc.send(pocDeployer.getSender(), { value: sentTons }, null);
+        const tonBalanceAfter = await poc.getBalance();
+        expect(tonBalanceAfter - expectedCommission > tonBalanceBefore);
+    });
+
+    // ----------------------------------------------------
+    // Utility funcitons for debugging
+    // ----------------------------------------------------
+
+    function replaceAddresses(str: string): string {
+        const replaceMany = (str: string, ...pairs: Array<[string, string]>): string => {
+            const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const lookup: Record<string, string> = Object.fromEntries(pairs);
+            const pattern = new RegExp(
+                pairs
+                    .map(([k]) => escape(k))
+                    .sort((a, b) => b.length - a.length)
+                    .join('|'),
+                'g',
+            );
+            return str.replace(pattern, (m) => lookup[m]!);
+        };
+        return replaceMany(
+            str,
+            [poc.address.toString(), 'poc'],
+            [pocDeployer.address.toString(), 'pocDeployer'],
+            [marketMaker.address.toString(), 'marketMaker'],
+            [launchMinter.address.toString(), 'launchMinter'],
+            [launchDeployer.address.toString(), 'launchDeployer'],
+            [launchDeployerWallet.address.toString(), 'launchWallet'],
+            [launchPocWallet.address.toString(), 'launchPocWallet'],
+            [collateralMinter ? collateralMinter.address.toString() : 'collateralMaster', 'collateralMaster'],
+            [
+                collateralDeployer ? collateralDeployer.address.toString() : 'jettonCollateralDeployer',
+                'collateralDeployer',
+            ],
+            [
+                collateralDeployerWallet ? collateralDeployerWallet.address.toString() : 'collateralWallet',
+                'collateralWallet',
+            ],
+            [
+                collateralPocWallet ? collateralPocWallet.address.toString() : 'collateralPocWallet',
+                'collateralPocWallet',
+            ],
+        );
+    }
+    function ppTx(tx: Transaction, mapFunc?: AddressMapFunc) {
+        const mapAddress = (address: Address | ExternalAddress | null | undefined) => {
+            return mapFunc ? (mapFunc(address) ?? address) : address;
+        };
+        const flatTx = flattenTransaction(tx);
+        let res = '';
+        const info = tx.inMessage?.info;
+        if (info) {
+            switch (info.type) {
+                case 'internal':
+                    res = `${mapAddress(info.src)} ➡️ ${mapAddress(info.dest)}\n  [internal]`;
+                    break;
+                case 'external-in':
+                    res = `${info.src ? mapAddress(info.src) : '???'} ➡️ ${mapAddress(info.dest)}\n  [external/in]`;
+                    break;
+                case 'external-out':
+                    res = `${mapAddress(info.src)} ➡️ ${info.dest ? mapAddress(info.dest) : '???'}\n  [external/out]`;
+                    break;
+            }
+        }
+        const success = ('actionPhase' in tx.description ? tx.description.actionPhase : undefined)?.success;
+        if (success !== undefined) {
+            if (success === true) {
+                res += ' [✅]';
+            } else if (success === false) {
+                res += ' [❌]';
+            }
+        }
+        if (flatTx.op !== undefined) {
+            res += ` [op=${'0x' + flatTx.op.toString(16)}]`;
+        }
+        res += '\n';
+        for (let message of tx.outMessages.values()) {
+            const dest = mapAddress(message.info.dest);
+            if (message.info.type === 'internal') {
+                res += `  out: ${fromNano(message.info.value.coins)}💎 ${dest}\n`;
+            } else {
+                res += `  out: ${dest}\n`;
+            }
+        }
+        return res;
+    }
+    function ppTxes(txs: Transaction[], mapFunc?: AddressMapFunc): string {
+        let out = '';
+        for (let tx of txs) {
+            out += replaceAddresses(ppTx(tx, mapFunc)) + '\n';
+        }
+        return out;
+    }
+    function ppBi(bi: bigint) {
+        return bi.toString().replace(/\B(?=(\d{3})+(?!\d))/g, '_');
+    }
+    function ppKnownContracts(): string {
+        return (
+            blockchain.snapshot().contracts.length,
+            replaceAddresses(
+                blockchain.snapshot().contracts.reduce((acc, c) => {
+                    return acc + c.address.toString() + '\n';
+                }, ''),
+            )
+        );
+    }
+});

--- a/wrappers/ExtendedJettonMinter.ts
+++ b/wrappers/ExtendedJettonMinter.ts
@@ -1,0 +1,193 @@
+//  SPDX-License-Identifier: MIT
+//  Copyright © 2025 TON Studio
+
+import {
+    ChangeOwner,
+    ClaimTON,
+    gasForBurn,
+    gasForTransfer,
+    JettonMinter,
+    JettonUpdateContent,
+    Mint,
+    minTonsForStorage,
+    ProvideWalletAddress,
+    storeMint,
+} from "./TestJetton_JettonMinter"
+import {Address, beginCell, Cell, ContractProvider, Sender, toNano} from "@ton/core"
+
+export class ExtendedJettonMinter extends JettonMinter {
+    constructor(address: Address, init?: {code: Cell; data: Cell}) {
+        super(address, init)
+    }
+
+    static async fromInit(totalSupply: bigint, owner: Address, jettonContent: Cell) {
+        const base = await JettonMinter.fromInit(totalSupply, owner, jettonContent, true)
+        if (base.init === undefined) {
+            throw new Error("JettonMinter init is not defined")
+        }
+        return new ExtendedJettonMinter(base.address, {code: base.init.code, data: base.init.data})
+    }
+
+    async getTotalSupply(provider: ContractProvider): Promise<bigint> {
+        const res = await this.getGetJettonData(provider)
+        return res.totalSupply
+    }
+
+    async getWalletAddress(provider: ContractProvider, owner: Address): Promise<Address> {
+        return this.getGetWalletAddress(provider, owner)
+    }
+
+    async getAdminAddress(provider: ContractProvider): Promise<Address> {
+        const res = await this.getGetJettonData(provider)
+        return res.adminAddress
+    }
+
+    async getContent(provider: ContractProvider): Promise<Cell> {
+        const res = await this.getGetJettonData(provider)
+        return res.jettonContent
+    }
+
+    /**
+     * Sends a mint message to the Jetton Minter contract to mint new Jettons for a specified recipient.
+     *
+     * @param provider - The contract provider used to interact with the blockchain.
+     * @param via - The sender object representing the wallet or account initiating the mint operation.
+     * @param to - The recipient address to which the newly minted Jettons will be sent.
+     * @param jettonAmount - The amount of Jettons to mint.
+     * @param forwardTonAmount - The amount of TONs to forward to the recipient along with the Jettons.
+     * @param totalTonAmount - The total amount of TONs to attach to the mint operation for fees and forwarding.
+     *
+     * @throws {Error} If the `totalTonAmount` is less than or equal to the `forwardTonAmount`.
+     *
+     * @returns A promise that resolves when the mint message has been sent.
+     *
+     * @example
+     * await jettonMinter.sendMint(
+     *     provider,
+     *     sender,
+     *     recipientAddress,
+     *     toNano("1000"), // Jetton amount
+     *     toNano("0.05"), // Forward TON amount
+     *     toNano("0.1"),  // Total TON amount
+     * );
+     */
+    async sendMint(
+        provider: ContractProvider,
+        via: Sender,
+        to: Address,
+        jettonAmount: bigint,
+        forwardTonAmount: bigint,
+        totalTonAmount: bigint,
+    ): Promise<void> {
+        if (totalTonAmount <= forwardTonAmount) {
+            throw new Error("Total TON amount should be greater than the forward amount")
+        }
+        const msg: Mint = {
+            $$type: "Mint",
+            queryId: 0n,
+            receiver: to,
+            mintMessage: {
+                $$type: "JettonTransferInternal",
+                queryId: 0n,
+                amount: jettonAmount,
+                sender: this.address,
+                responseDestination: this.address,
+                forwardTonAmount: forwardTonAmount,
+                forwardPayload: beginCell().storeUint(0, 1).asSlice(),
+            },
+        }
+        return this.send(provider, via, {value: totalTonAmount + toNano("0.015")}, msg)
+    }
+
+    async sendChangeAdmin(
+        provider: ContractProvider,
+        via: Sender,
+        newOwner: Address,
+    ): Promise<void> {
+        const msg: ChangeOwner = {
+            $$type: "ChangeOwner",
+            queryId: 0n,
+            newOwner: newOwner,
+        }
+        return this.send(provider, via, {value: toNano("0.05")}, msg)
+    }
+
+    async sendChangeContent(provider: ContractProvider, via: Sender, content: Cell): Promise<void> {
+        const msg: JettonUpdateContent = {
+            $$type: "JettonUpdateContent",
+            queryId: 0n,
+            content: content,
+        }
+        return this.send(provider, via, {value: toNano("0.05")}, msg)
+    }
+
+    async sendDiscovery(
+        provider: ContractProvider,
+        via: Sender,
+        address: Address,
+        includeAddress: boolean,
+        value: bigint = toNano("0.1"),
+    ): Promise<void> {
+        const msg: ProvideWalletAddress = {
+            $$type: "ProvideWalletAddress",
+            queryId: 0n,
+            ownerAddress: address,
+            includeAddress: includeAddress,
+        }
+        return this.send(provider, via, {value: value}, msg)
+    }
+
+    async sendClaimTon(
+        provider: ContractProvider,
+        via: Sender,
+        address: Address,
+        value: bigint = toNano("0.1"),
+    ): Promise<void> {
+        const msg: ClaimTON = {
+            $$type: "ClaimTON",
+            receiver: address,
+        }
+        return this.send(provider, via, {value: value}, msg)
+    }
+
+    loadMintMessage(
+        mintAmount: bigint,
+        receiver: Address,
+        sender: Address,
+        responseDestination: Address,
+        forwardTonAmount: bigint,
+        forwardPayload: Cell | null,
+    ): Cell {
+        return beginCell()
+            .store(
+                storeMint({
+                    $$type: "Mint",
+                    mintMessage: {
+                        $$type: "JettonTransferInternal",
+                        amount: mintAmount,
+                        sender: sender,
+                        responseDestination: responseDestination,
+                        queryId: 0n,
+                        forwardTonAmount: forwardTonAmount,
+                        forwardPayload: beginCell().storeMaybeRef(forwardPayload).asSlice(),
+                    },
+                    queryId: 0n,
+                    receiver: receiver,
+                }),
+            )
+            .endCell()
+    }
+
+    loadGasForBurn(): bigint {
+        return gasForBurn
+    }
+
+    loadGasForTransfer(): bigint {
+        return gasForTransfer
+    }
+
+    loadMinTonsForStorage(): bigint {
+        return minTonsForStorage
+    }
+}
+

--- a/wrappers/ExtendedJettonWallet.ts
+++ b/wrappers/ExtendedJettonWallet.ts
@@ -1,0 +1,163 @@
+//  SPDX-License-Identifier: MIT
+//  Copyright © 2025 TON Studio
+
+import {
+    ClaimTON,
+    JettonTransfer,
+    JettonWallet,
+    walletStateInitCells,
+    walletStateInitBits,
+} from "./TestJetton_JettonWallet"
+import {Address, Builder, Cell, ContractProvider, Sender, toNano} from "@ton/core"
+import {JettonBurn, ProvideWalletBalance} from "./TestJetton_JettonMinter"
+
+export class ExtendedJettonWallet extends JettonWallet {
+    constructor(address: Address, init?: {code: Cell; data: Cell}) {
+        super(address, init)
+    }
+
+    static async fromInit(owner: Address, minter: Address, balance: bigint) {
+        const base = await JettonWallet.fromInit(owner, minter, balance)
+        if (base.init === undefined) {
+            throw new Error("JettonWallet init is not defined")
+        }
+        return new ExtendedJettonWallet(base.address, {code: base.init.code, data: base.init.data})
+    }
+
+    getJettonBalance = async (provider: ContractProvider): Promise<bigint> => {
+        const state = await provider.getState()
+        if (state.state.type !== "active") {
+            return 0n
+        }
+        return (await this.getGetWalletData(provider)).balance
+    }
+
+    /**
+     * Sends a Jetton transfer message from this wallet to a specified recipient.
+     *
+     * @param provider - The contract provider used to interact with the blockchain. Automatically passed by the test environment proxy
+     * @param via - The sender object representing the wallet or account initiating the transfer.
+     * @param value - The amount of TONs to attach to the transfer for fees and forwarding.
+     * @param jettonAmount - The amount of Jettons to transfer.
+     * @param to - The recipient address to which the Jettons will be sent.
+     * @param responseAddress - The address to receive the response from the transfer operation (Jetton excesses)
+     * @param customPayload - An optional custom payload to include in the transfer message.
+     * @param forwardTonAmount - The amount of TONs to forward to the recipient along with the Jettons.
+     * @param forwardPayload - An optional payload to include in the forwarded message to the recipient.
+     *
+     * @returns A promise that resolves when the transfer message has been sent, returns SendResult.
+     *
+     * @example
+     * await jettonWallet.sendTransfer(
+     *     provider,
+     *     sender,
+     *     toNano("0.05"),
+     *     toNano("100"),
+     *     recipientAddress,
+     *     responseAddress,
+     *     null,
+     *     toNano("0.01"),
+     *     null
+     * );
+     */
+    sendTransfer = async (
+        provider: ContractProvider,
+        via: Sender,
+        value: bigint,
+        jettonAmount: bigint,
+        to: Address,
+        responseAddress: Address,
+        customPayload: Cell | null,
+        forwardTonAmount: bigint,
+        forwardPayload: Cell | null,
+    ): Promise<void> => {
+        const parsedForwardPayload =
+            forwardPayload != null
+                ? forwardPayload.beginParse()
+                : new Builder().storeUint(0, 1).endCell().beginParse()
+
+        const msg: JettonTransfer = {
+            $$type: "JettonTransfer",
+            queryId: 0n,
+            amount: jettonAmount,
+            destination: to,
+            responseDestination: responseAddress,
+            customPayload: customPayload,
+            forwardTonAmount: forwardTonAmount,
+            forwardPayload: parsedForwardPayload,
+        }
+
+        await this.send(provider, via, {value}, msg)
+    }
+
+    sendBurn = async (
+        provider: ContractProvider,
+        via: Sender,
+        value: bigint,
+        jettonAmount: bigint,
+        responseAddress: Address | null,
+        customPayload: Cell | null,
+    ): Promise<void> => {
+        const msg: JettonBurn = {
+            $$type: "JettonBurn",
+            queryId: 0n,
+            amount: jettonAmount,
+            responseDestination: responseAddress,
+            customPayload: customPayload,
+        }
+
+        await this.send(provider, via, {value}, msg)
+    }
+
+    sendProvideWalletBalance = async (
+        provider: ContractProvider,
+        via: Sender,
+        value: bigint,
+        receiver: Address,
+        includeInfo: boolean,
+    ): Promise<void> => {
+        const msg: ProvideWalletBalance = {
+            $$type: "ProvideWalletBalance",
+            receiver: receiver,
+            includeVerifyInfo: includeInfo,
+        }
+
+        await this.send(provider, via, {value}, msg)
+    }
+
+    async sendClaimTon(
+        provider: ContractProvider,
+        via: Sender,
+        address: Address,
+        value: bigint = toNano("0.1"),
+    ): Promise<void> {
+        const msg: ClaimTON = {
+            $$type: "ClaimTON",
+            receiver: address,
+        }
+        return this.send(provider, via, {value: value}, msg)
+    }
+
+    // for compatibility with the reference implementation tests
+    sendWithdrawTons = async (_provider: ContractProvider, _via: Sender): Promise<void> => {
+        throw new Error("Not implemented")
+    }
+
+    sendWithdrawJettons = async (
+        _provider: ContractProvider,
+        _via: Sender,
+        _from: Address,
+        _amount: bigint,
+    ): Promise<void> => {
+        throw new Error("Not implemented")
+    }
+
+    loadWalletStateInitCells(): bigint {
+        return walletStateInitCells
+    }
+
+    loadWalletStateInitBits(): bigint {
+        return walletStateInitBits
+    }
+}
+

--- a/wrappers/TestJetton_JettonMinter.ts
+++ b/wrappers/TestJetton_JettonMinter.ts
@@ -1,0 +1,2250 @@
+import {
+    Cell,
+    Slice,
+    Address,
+    Builder,
+    beginCell,
+    ComputeError,
+    TupleItem,
+    TupleReader,
+    Dictionary,
+    contractAddress,
+    address,
+    ContractProvider,
+    Sender,
+    Contract,
+    ContractABI,
+    ABIType,
+    ABIGetter,
+    ABIReceiver,
+    TupleBuilder,
+    DictionaryValue
+} from '@ton/core';
+
+export type DataSize = {
+    $$type: 'DataSize';
+    cells: bigint;
+    bits: bigint;
+    refs: bigint;
+}
+
+export function storeDataSize(src: DataSize) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.cells, 257);
+        b_0.storeInt(src.bits, 257);
+        b_0.storeInt(src.refs, 257);
+    };
+}
+
+export function loadDataSize(slice: Slice) {
+    const sc_0 = slice;
+    const _cells = sc_0.loadIntBig(257);
+    const _bits = sc_0.loadIntBig(257);
+    const _refs = sc_0.loadIntBig(257);
+    return { $$type: 'DataSize' as const, cells: _cells, bits: _bits, refs: _refs };
+}
+
+export function loadTupleDataSize(source: TupleReader) {
+    const _cells = source.readBigNumber();
+    const _bits = source.readBigNumber();
+    const _refs = source.readBigNumber();
+    return { $$type: 'DataSize' as const, cells: _cells, bits: _bits, refs: _refs };
+}
+
+export function loadGetterTupleDataSize(source: TupleReader) {
+    const _cells = source.readBigNumber();
+    const _bits = source.readBigNumber();
+    const _refs = source.readBigNumber();
+    return { $$type: 'DataSize' as const, cells: _cells, bits: _bits, refs: _refs };
+}
+
+export function storeTupleDataSize(source: DataSize) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.cells);
+    builder.writeNumber(source.bits);
+    builder.writeNumber(source.refs);
+    return builder.build();
+}
+
+export function dictValueParserDataSize(): DictionaryValue<DataSize> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeDataSize(src)).endCell());
+        },
+        parse: (src) => {
+            return loadDataSize(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type SignedBundle = {
+    $$type: 'SignedBundle';
+    signature: Buffer;
+    signedData: Slice;
+}
+
+export function storeSignedBundle(src: SignedBundle) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeBuffer(src.signature);
+        b_0.storeBuilder(src.signedData.asBuilder());
+    };
+}
+
+export function loadSignedBundle(slice: Slice) {
+    const sc_0 = slice;
+    const _signature = sc_0.loadBuffer(64);
+    const _signedData = sc_0;
+    return { $$type: 'SignedBundle' as const, signature: _signature, signedData: _signedData };
+}
+
+export function loadTupleSignedBundle(source: TupleReader) {
+    const _signature = source.readBuffer();
+    const _signedData = source.readCell().asSlice();
+    return { $$type: 'SignedBundle' as const, signature: _signature, signedData: _signedData };
+}
+
+export function loadGetterTupleSignedBundle(source: TupleReader) {
+    const _signature = source.readBuffer();
+    const _signedData = source.readCell().asSlice();
+    return { $$type: 'SignedBundle' as const, signature: _signature, signedData: _signedData };
+}
+
+export function storeTupleSignedBundle(source: SignedBundle) {
+    const builder = new TupleBuilder();
+    builder.writeBuffer(source.signature);
+    builder.writeSlice(source.signedData.asCell());
+    return builder.build();
+}
+
+export function dictValueParserSignedBundle(): DictionaryValue<SignedBundle> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeSignedBundle(src)).endCell());
+        },
+        parse: (src) => {
+            return loadSignedBundle(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type StateInit = {
+    $$type: 'StateInit';
+    code: Cell;
+    data: Cell;
+}
+
+export function storeStateInit(src: StateInit) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeRef(src.code);
+        b_0.storeRef(src.data);
+    };
+}
+
+export function loadStateInit(slice: Slice) {
+    const sc_0 = slice;
+    const _code = sc_0.loadRef();
+    const _data = sc_0.loadRef();
+    return { $$type: 'StateInit' as const, code: _code, data: _data };
+}
+
+export function loadTupleStateInit(source: TupleReader) {
+    const _code = source.readCell();
+    const _data = source.readCell();
+    return { $$type: 'StateInit' as const, code: _code, data: _data };
+}
+
+export function loadGetterTupleStateInit(source: TupleReader) {
+    const _code = source.readCell();
+    const _data = source.readCell();
+    return { $$type: 'StateInit' as const, code: _code, data: _data };
+}
+
+export function storeTupleStateInit(source: StateInit) {
+    const builder = new TupleBuilder();
+    builder.writeCell(source.code);
+    builder.writeCell(source.data);
+    return builder.build();
+}
+
+export function dictValueParserStateInit(): DictionaryValue<StateInit> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeStateInit(src)).endCell());
+        },
+        parse: (src) => {
+            return loadStateInit(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type Context = {
+    $$type: 'Context';
+    bounceable: boolean;
+    sender: Address;
+    value: bigint;
+    raw: Slice;
+}
+
+export function storeContext(src: Context) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeBit(src.bounceable);
+        b_0.storeAddress(src.sender);
+        b_0.storeInt(src.value, 257);
+        b_0.storeRef(src.raw.asCell());
+    };
+}
+
+export function loadContext(slice: Slice) {
+    const sc_0 = slice;
+    const _bounceable = sc_0.loadBit();
+    const _sender = sc_0.loadAddress();
+    const _value = sc_0.loadIntBig(257);
+    const _raw = sc_0.loadRef().asSlice();
+    return { $$type: 'Context' as const, bounceable: _bounceable, sender: _sender, value: _value, raw: _raw };
+}
+
+export function loadTupleContext(source: TupleReader) {
+    const _bounceable = source.readBoolean();
+    const _sender = source.readAddress();
+    const _value = source.readBigNumber();
+    const _raw = source.readCell().asSlice();
+    return { $$type: 'Context' as const, bounceable: _bounceable, sender: _sender, value: _value, raw: _raw };
+}
+
+export function loadGetterTupleContext(source: TupleReader) {
+    const _bounceable = source.readBoolean();
+    const _sender = source.readAddress();
+    const _value = source.readBigNumber();
+    const _raw = source.readCell().asSlice();
+    return { $$type: 'Context' as const, bounceable: _bounceable, sender: _sender, value: _value, raw: _raw };
+}
+
+export function storeTupleContext(source: Context) {
+    const builder = new TupleBuilder();
+    builder.writeBoolean(source.bounceable);
+    builder.writeAddress(source.sender);
+    builder.writeNumber(source.value);
+    builder.writeSlice(source.raw.asCell());
+    return builder.build();
+}
+
+export function dictValueParserContext(): DictionaryValue<Context> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeContext(src)).endCell());
+        },
+        parse: (src) => {
+            return loadContext(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type SendParameters = {
+    $$type: 'SendParameters';
+    mode: bigint;
+    body: Cell | null;
+    code: Cell | null;
+    data: Cell | null;
+    value: bigint;
+    to: Address;
+    bounce: boolean;
+}
+
+export function storeSendParameters(src: SendParameters) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.mode, 257);
+        if (src.body !== null && src.body !== undefined) { b_0.storeBit(true).storeRef(src.body); } else { b_0.storeBit(false); }
+        if (src.code !== null && src.code !== undefined) { b_0.storeBit(true).storeRef(src.code); } else { b_0.storeBit(false); }
+        if (src.data !== null && src.data !== undefined) { b_0.storeBit(true).storeRef(src.data); } else { b_0.storeBit(false); }
+        b_0.storeInt(src.value, 257);
+        b_0.storeAddress(src.to);
+        b_0.storeBit(src.bounce);
+    };
+}
+
+export function loadSendParameters(slice: Slice) {
+    const sc_0 = slice;
+    const _mode = sc_0.loadIntBig(257);
+    const _body = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _code = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _data = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _value = sc_0.loadIntBig(257);
+    const _to = sc_0.loadAddress();
+    const _bounce = sc_0.loadBit();
+    return { $$type: 'SendParameters' as const, mode: _mode, body: _body, code: _code, data: _data, value: _value, to: _to, bounce: _bounce };
+}
+
+export function loadTupleSendParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _code = source.readCellOpt();
+    const _data = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _to = source.readAddress();
+    const _bounce = source.readBoolean();
+    return { $$type: 'SendParameters' as const, mode: _mode, body: _body, code: _code, data: _data, value: _value, to: _to, bounce: _bounce };
+}
+
+export function loadGetterTupleSendParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _code = source.readCellOpt();
+    const _data = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _to = source.readAddress();
+    const _bounce = source.readBoolean();
+    return { $$type: 'SendParameters' as const, mode: _mode, body: _body, code: _code, data: _data, value: _value, to: _to, bounce: _bounce };
+}
+
+export function storeTupleSendParameters(source: SendParameters) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.mode);
+    builder.writeCell(source.body);
+    builder.writeCell(source.code);
+    builder.writeCell(source.data);
+    builder.writeNumber(source.value);
+    builder.writeAddress(source.to);
+    builder.writeBoolean(source.bounce);
+    return builder.build();
+}
+
+export function dictValueParserSendParameters(): DictionaryValue<SendParameters> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeSendParameters(src)).endCell());
+        },
+        parse: (src) => {
+            return loadSendParameters(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type MessageParameters = {
+    $$type: 'MessageParameters';
+    mode: bigint;
+    body: Cell | null;
+    value: bigint;
+    to: Address;
+    bounce: boolean;
+}
+
+export function storeMessageParameters(src: MessageParameters) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.mode, 257);
+        if (src.body !== null && src.body !== undefined) { b_0.storeBit(true).storeRef(src.body); } else { b_0.storeBit(false); }
+        b_0.storeInt(src.value, 257);
+        b_0.storeAddress(src.to);
+        b_0.storeBit(src.bounce);
+    };
+}
+
+export function loadMessageParameters(slice: Slice) {
+    const sc_0 = slice;
+    const _mode = sc_0.loadIntBig(257);
+    const _body = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _value = sc_0.loadIntBig(257);
+    const _to = sc_0.loadAddress();
+    const _bounce = sc_0.loadBit();
+    return { $$type: 'MessageParameters' as const, mode: _mode, body: _body, value: _value, to: _to, bounce: _bounce };
+}
+
+export function loadTupleMessageParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _to = source.readAddress();
+    const _bounce = source.readBoolean();
+    return { $$type: 'MessageParameters' as const, mode: _mode, body: _body, value: _value, to: _to, bounce: _bounce };
+}
+
+export function loadGetterTupleMessageParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _to = source.readAddress();
+    const _bounce = source.readBoolean();
+    return { $$type: 'MessageParameters' as const, mode: _mode, body: _body, value: _value, to: _to, bounce: _bounce };
+}
+
+export function storeTupleMessageParameters(source: MessageParameters) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.mode);
+    builder.writeCell(source.body);
+    builder.writeNumber(source.value);
+    builder.writeAddress(source.to);
+    builder.writeBoolean(source.bounce);
+    return builder.build();
+}
+
+export function dictValueParserMessageParameters(): DictionaryValue<MessageParameters> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeMessageParameters(src)).endCell());
+        },
+        parse: (src) => {
+            return loadMessageParameters(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type DeployParameters = {
+    $$type: 'DeployParameters';
+    mode: bigint;
+    body: Cell | null;
+    value: bigint;
+    bounce: boolean;
+    init: StateInit;
+}
+
+export function storeDeployParameters(src: DeployParameters) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.mode, 257);
+        if (src.body !== null && src.body !== undefined) { b_0.storeBit(true).storeRef(src.body); } else { b_0.storeBit(false); }
+        b_0.storeInt(src.value, 257);
+        b_0.storeBit(src.bounce);
+        b_0.store(storeStateInit(src.init));
+    };
+}
+
+export function loadDeployParameters(slice: Slice) {
+    const sc_0 = slice;
+    const _mode = sc_0.loadIntBig(257);
+    const _body = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _value = sc_0.loadIntBig(257);
+    const _bounce = sc_0.loadBit();
+    const _init = loadStateInit(sc_0);
+    return { $$type: 'DeployParameters' as const, mode: _mode, body: _body, value: _value, bounce: _bounce, init: _init };
+}
+
+export function loadTupleDeployParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _bounce = source.readBoolean();
+    const _init = loadTupleStateInit(source);
+    return { $$type: 'DeployParameters' as const, mode: _mode, body: _body, value: _value, bounce: _bounce, init: _init };
+}
+
+export function loadGetterTupleDeployParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _bounce = source.readBoolean();
+    const _init = loadGetterTupleStateInit(source);
+    return { $$type: 'DeployParameters' as const, mode: _mode, body: _body, value: _value, bounce: _bounce, init: _init };
+}
+
+export function storeTupleDeployParameters(source: DeployParameters) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.mode);
+    builder.writeCell(source.body);
+    builder.writeNumber(source.value);
+    builder.writeBoolean(source.bounce);
+    builder.writeTuple(storeTupleStateInit(source.init));
+    return builder.build();
+}
+
+export function dictValueParserDeployParameters(): DictionaryValue<DeployParameters> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeDeployParameters(src)).endCell());
+        },
+        parse: (src) => {
+            return loadDeployParameters(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type StdAddress = {
+    $$type: 'StdAddress';
+    workchain: bigint;
+    address: bigint;
+}
+
+export function storeStdAddress(src: StdAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.workchain, 8);
+        b_0.storeUint(src.address, 256);
+    };
+}
+
+export function loadStdAddress(slice: Slice) {
+    const sc_0 = slice;
+    const _workchain = sc_0.loadIntBig(8);
+    const _address = sc_0.loadUintBig(256);
+    return { $$type: 'StdAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function loadTupleStdAddress(source: TupleReader) {
+    const _workchain = source.readBigNumber();
+    const _address = source.readBigNumber();
+    return { $$type: 'StdAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function loadGetterTupleStdAddress(source: TupleReader) {
+    const _workchain = source.readBigNumber();
+    const _address = source.readBigNumber();
+    return { $$type: 'StdAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function storeTupleStdAddress(source: StdAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.workchain);
+    builder.writeNumber(source.address);
+    return builder.build();
+}
+
+export function dictValueParserStdAddress(): DictionaryValue<StdAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeStdAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadStdAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type VarAddress = {
+    $$type: 'VarAddress';
+    workchain: bigint;
+    address: Slice;
+}
+
+export function storeVarAddress(src: VarAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.workchain, 32);
+        b_0.storeRef(src.address.asCell());
+    };
+}
+
+export function loadVarAddress(slice: Slice) {
+    const sc_0 = slice;
+    const _workchain = sc_0.loadIntBig(32);
+    const _address = sc_0.loadRef().asSlice();
+    return { $$type: 'VarAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function loadTupleVarAddress(source: TupleReader) {
+    const _workchain = source.readBigNumber();
+    const _address = source.readCell().asSlice();
+    return { $$type: 'VarAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function loadGetterTupleVarAddress(source: TupleReader) {
+    const _workchain = source.readBigNumber();
+    const _address = source.readCell().asSlice();
+    return { $$type: 'VarAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function storeTupleVarAddress(source: VarAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.workchain);
+    builder.writeSlice(source.address.asCell());
+    return builder.build();
+}
+
+export function dictValueParserVarAddress(): DictionaryValue<VarAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeVarAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadVarAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type BasechainAddress = {
+    $$type: 'BasechainAddress';
+    hash: bigint | null;
+}
+
+export function storeBasechainAddress(src: BasechainAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        if (src.hash !== null && src.hash !== undefined) { b_0.storeBit(true).storeInt(src.hash, 257); } else { b_0.storeBit(false); }
+    };
+}
+
+export function loadBasechainAddress(slice: Slice) {
+    const sc_0 = slice;
+    const _hash = sc_0.loadBit() ? sc_0.loadIntBig(257) : null;
+    return { $$type: 'BasechainAddress' as const, hash: _hash };
+}
+
+export function loadTupleBasechainAddress(source: TupleReader) {
+    const _hash = source.readBigNumberOpt();
+    return { $$type: 'BasechainAddress' as const, hash: _hash };
+}
+
+export function loadGetterTupleBasechainAddress(source: TupleReader) {
+    const _hash = source.readBigNumberOpt();
+    return { $$type: 'BasechainAddress' as const, hash: _hash };
+}
+
+export function storeTupleBasechainAddress(source: BasechainAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.hash);
+    return builder.build();
+}
+
+export function dictValueParserBasechainAddress(): DictionaryValue<BasechainAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeBasechainAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadBasechainAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonWallet$Data = {
+    $$type: 'JettonWallet$Data';
+    owner: Address;
+    minter: Address;
+    balance: bigint;
+}
+
+export function storeJettonWallet$Data(src: JettonWallet$Data) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeAddress(src.owner);
+        b_0.storeAddress(src.minter);
+        b_0.storeCoins(src.balance);
+    };
+}
+
+export function loadJettonWallet$Data(slice: Slice) {
+    const sc_0 = slice;
+    const _owner = sc_0.loadAddress();
+    const _minter = sc_0.loadAddress();
+    const _balance = sc_0.loadCoins();
+    return { $$type: 'JettonWallet$Data' as const, owner: _owner, minter: _minter, balance: _balance };
+}
+
+export function loadTupleJettonWallet$Data(source: TupleReader) {
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _balance = source.readBigNumber();
+    return { $$type: 'JettonWallet$Data' as const, owner: _owner, minter: _minter, balance: _balance };
+}
+
+export function loadGetterTupleJettonWallet$Data(source: TupleReader) {
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _balance = source.readBigNumber();
+    return { $$type: 'JettonWallet$Data' as const, owner: _owner, minter: _minter, balance: _balance };
+}
+
+export function storeTupleJettonWallet$Data(source: JettonWallet$Data) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.owner);
+    builder.writeAddress(source.minter);
+    builder.writeNumber(source.balance);
+    return builder.build();
+}
+
+export function dictValueParserJettonWallet$Data(): DictionaryValue<JettonWallet$Data> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonWallet$Data(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonWallet$Data(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonData = {
+    $$type: 'JettonData';
+    totalSupply: bigint;
+    mintable: boolean;
+    owner: Address;
+    content: Cell;
+    jettonWalletCode: Cell;
+}
+
+export function storeJettonData(src: JettonData) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.totalSupply, 257);
+        b_0.storeBit(src.mintable);
+        b_0.storeAddress(src.owner);
+        b_0.storeRef(src.content);
+        b_0.storeRef(src.jettonWalletCode);
+    };
+}
+
+export function loadJettonData(slice: Slice) {
+    const sc_0 = slice;
+    const _totalSupply = sc_0.loadIntBig(257);
+    const _mintable = sc_0.loadBit();
+    const _owner = sc_0.loadAddress();
+    const _content = sc_0.loadRef();
+    const _jettonWalletCode = sc_0.loadRef();
+    return { $$type: 'JettonData' as const, totalSupply: _totalSupply, mintable: _mintable, owner: _owner, content: _content, jettonWalletCode: _jettonWalletCode };
+}
+
+export function loadTupleJettonData(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _mintable = source.readBoolean();
+    const _owner = source.readAddress();
+    const _content = source.readCell();
+    const _jettonWalletCode = source.readCell();
+    return { $$type: 'JettonData' as const, totalSupply: _totalSupply, mintable: _mintable, owner: _owner, content: _content, jettonWalletCode: _jettonWalletCode };
+}
+
+export function loadGetterTupleJettonData(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _mintable = source.readBoolean();
+    const _owner = source.readAddress();
+    const _content = source.readCell();
+    const _jettonWalletCode = source.readCell();
+    return { $$type: 'JettonData' as const, totalSupply: _totalSupply, mintable: _mintable, owner: _owner, content: _content, jettonWalletCode: _jettonWalletCode };
+}
+
+export function storeTupleJettonData(source: JettonData) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.totalSupply);
+    builder.writeBoolean(source.mintable);
+    builder.writeAddress(source.owner);
+    builder.writeCell(source.content);
+    builder.writeCell(source.jettonWalletCode);
+    return builder.build();
+}
+
+export function dictValueParserJettonData(): DictionaryValue<JettonData> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonData(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonData(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonWalletData = {
+    $$type: 'JettonWalletData';
+    balance: bigint;
+    owner: Address;
+    minter: Address;
+    code: Cell;
+}
+
+export function storeJettonWalletData(src: JettonWalletData) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.balance, 257);
+        b_0.storeAddress(src.owner);
+        b_0.storeAddress(src.minter);
+        b_0.storeRef(src.code);
+    };
+}
+
+export function loadJettonWalletData(slice: Slice) {
+    const sc_0 = slice;
+    const _balance = sc_0.loadIntBig(257);
+    const _owner = sc_0.loadAddress();
+    const _minter = sc_0.loadAddress();
+    const _code = sc_0.loadRef();
+    return { $$type: 'JettonWalletData' as const, balance: _balance, owner: _owner, minter: _minter, code: _code };
+}
+
+export function loadTupleJettonWalletData(source: TupleReader) {
+    const _balance = source.readBigNumber();
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _code = source.readCell();
+    return { $$type: 'JettonWalletData' as const, balance: _balance, owner: _owner, minter: _minter, code: _code };
+}
+
+export function loadGetterTupleJettonWalletData(source: TupleReader) {
+    const _balance = source.readBigNumber();
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _code = source.readCell();
+    return { $$type: 'JettonWalletData' as const, balance: _balance, owner: _owner, minter: _minter, code: _code };
+}
+
+export function storeTupleJettonWalletData(source: JettonWalletData) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.balance);
+    builder.writeAddress(source.owner);
+    builder.writeAddress(source.minter);
+    builder.writeCell(source.code);
+    return builder.build();
+}
+
+export function dictValueParserJettonWalletData(): DictionaryValue<JettonWalletData> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonWalletData(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonWalletData(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type MaybeAddress = {
+    $$type: 'MaybeAddress';
+    address: Address | null;
+}
+
+export function storeMaybeAddress(src: MaybeAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeAddress(src.address);
+    };
+}
+
+export function loadMaybeAddress(slice: Slice) {
+    const sc_0 = slice;
+    const _address = sc_0.loadMaybeAddress();
+    return { $$type: 'MaybeAddress' as const, address: _address };
+}
+
+export function loadTupleMaybeAddress(source: TupleReader) {
+    const _address = source.readAddressOpt();
+    return { $$type: 'MaybeAddress' as const, address: _address };
+}
+
+export function loadGetterTupleMaybeAddress(source: TupleReader) {
+    const _address = source.readAddressOpt();
+    return { $$type: 'MaybeAddress' as const, address: _address };
+}
+
+export function storeTupleMaybeAddress(source: MaybeAddress) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.address);
+    return builder.build();
+}
+
+export function dictValueParserMaybeAddress(): DictionaryValue<MaybeAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeMaybeAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadMaybeAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonUpdateContent = {
+    $$type: 'JettonUpdateContent';
+    queryId: bigint;
+    content: Cell;
+}
+
+export function storeJettonUpdateContent(src: JettonUpdateContent) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(4, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeRef(src.content);
+    };
+}
+
+export function loadJettonUpdateContent(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 4) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _content = sc_0.loadRef();
+    return { $$type: 'JettonUpdateContent' as const, queryId: _queryId, content: _content };
+}
+
+export function loadTupleJettonUpdateContent(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _content = source.readCell();
+    return { $$type: 'JettonUpdateContent' as const, queryId: _queryId, content: _content };
+}
+
+export function loadGetterTupleJettonUpdateContent(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _content = source.readCell();
+    return { $$type: 'JettonUpdateContent' as const, queryId: _queryId, content: _content };
+}
+
+export function storeTupleJettonUpdateContent(source: JettonUpdateContent) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeCell(source.content);
+    return builder.build();
+}
+
+export function dictValueParserJettonUpdateContent(): DictionaryValue<JettonUpdateContent> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonUpdateContent(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonUpdateContent(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonTransfer = {
+    $$type: 'JettonTransfer';
+    queryId: bigint;
+    amount: bigint;
+    destination: Address;
+    responseDestination: Address | null;
+    customPayload: Cell | null;
+    forwardTonAmount: bigint;
+    forwardPayload: Slice;
+}
+
+export function storeJettonTransfer(src: JettonTransfer) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(260734629, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.destination);
+        b_0.storeAddress(src.responseDestination);
+        if (src.customPayload !== null && src.customPayload !== undefined) { b_0.storeBit(true).storeRef(src.customPayload); } else { b_0.storeBit(false); }
+        b_0.storeCoins(src.forwardTonAmount);
+        b_0.storeBuilder(src.forwardPayload.asBuilder());
+    };
+}
+
+export function loadJettonTransfer(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 260734629) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _destination = sc_0.loadAddress();
+    const _responseDestination = sc_0.loadMaybeAddress();
+    const _customPayload = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _forwardTonAmount = sc_0.loadCoins();
+    const _forwardPayload = sc_0;
+    return { $$type: 'JettonTransfer' as const, queryId: _queryId, amount: _amount, destination: _destination, responseDestination: _responseDestination, customPayload: _customPayload, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function loadTupleJettonTransfer(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _destination = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    const _customPayload = source.readCellOpt();
+    const _forwardTonAmount = source.readBigNumber();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonTransfer' as const, queryId: _queryId, amount: _amount, destination: _destination, responseDestination: _responseDestination, customPayload: _customPayload, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function loadGetterTupleJettonTransfer(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _destination = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    const _customPayload = source.readCellOpt();
+    const _forwardTonAmount = source.readBigNumber();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonTransfer' as const, queryId: _queryId, amount: _amount, destination: _destination, responseDestination: _responseDestination, customPayload: _customPayload, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function storeTupleJettonTransfer(source: JettonTransfer) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.destination);
+    builder.writeAddress(source.responseDestination);
+    builder.writeCell(source.customPayload);
+    builder.writeNumber(source.forwardTonAmount);
+    builder.writeSlice(source.forwardPayload.asCell());
+    return builder.build();
+}
+
+export function dictValueParserJettonTransfer(): DictionaryValue<JettonTransfer> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonTransfer(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonTransfer(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonTransferInternal = {
+    $$type: 'JettonTransferInternal';
+    queryId: bigint;
+    amount: bigint;
+    sender: Address;
+    responseDestination: Address | null;
+    forwardTonAmount: bigint;
+    forwardPayload: Slice;
+}
+
+export function storeJettonTransferInternal(src: JettonTransferInternal) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(395134233, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.sender);
+        b_0.storeAddress(src.responseDestination);
+        b_0.storeCoins(src.forwardTonAmount);
+        b_0.storeBuilder(src.forwardPayload.asBuilder());
+    };
+}
+
+export function loadJettonTransferInternal(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 395134233) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _sender = sc_0.loadAddress();
+    const _responseDestination = sc_0.loadMaybeAddress();
+    const _forwardTonAmount = sc_0.loadCoins();
+    const _forwardPayload = sc_0;
+    return { $$type: 'JettonTransferInternal' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function loadTupleJettonTransferInternal(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    const _forwardTonAmount = source.readBigNumber();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonTransferInternal' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function loadGetterTupleJettonTransferInternal(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    const _forwardTonAmount = source.readBigNumber();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonTransferInternal' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function storeTupleJettonTransferInternal(source: JettonTransferInternal) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.sender);
+    builder.writeAddress(source.responseDestination);
+    builder.writeNumber(source.forwardTonAmount);
+    builder.writeSlice(source.forwardPayload.asCell());
+    return builder.build();
+}
+
+export function dictValueParserJettonTransferInternal(): DictionaryValue<JettonTransferInternal> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonTransferInternal(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonTransferInternal(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonNotification = {
+    $$type: 'JettonNotification';
+    queryId: bigint;
+    amount: bigint;
+    sender: Address;
+    forwardPayload: Slice;
+}
+
+export function storeJettonNotification(src: JettonNotification) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(1935855772, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.sender);
+        b_0.storeBuilder(src.forwardPayload.asBuilder());
+    };
+}
+
+export function loadJettonNotification(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 1935855772) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _sender = sc_0.loadAddress();
+    const _forwardPayload = sc_0;
+    return { $$type: 'JettonNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, forwardPayload: _forwardPayload };
+}
+
+export function loadTupleJettonNotification(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, forwardPayload: _forwardPayload };
+}
+
+export function loadGetterTupleJettonNotification(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, forwardPayload: _forwardPayload };
+}
+
+export function storeTupleJettonNotification(source: JettonNotification) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.sender);
+    builder.writeSlice(source.forwardPayload.asCell());
+    return builder.build();
+}
+
+export function dictValueParserJettonNotification(): DictionaryValue<JettonNotification> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonNotification(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonNotification(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonBurn = {
+    $$type: 'JettonBurn';
+    queryId: bigint;
+    amount: bigint;
+    responseDestination: Address | null;
+    customPayload: Cell | null;
+}
+
+export function storeJettonBurn(src: JettonBurn) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(1499400124, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.responseDestination);
+        if (src.customPayload !== null && src.customPayload !== undefined) { b_0.storeBit(true).storeRef(src.customPayload); } else { b_0.storeBit(false); }
+    };
+}
+
+export function loadJettonBurn(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 1499400124) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _responseDestination = sc_0.loadMaybeAddress();
+    const _customPayload = sc_0.loadBit() ? sc_0.loadRef() : null;
+    return { $$type: 'JettonBurn' as const, queryId: _queryId, amount: _amount, responseDestination: _responseDestination, customPayload: _customPayload };
+}
+
+export function loadTupleJettonBurn(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _responseDestination = source.readAddressOpt();
+    const _customPayload = source.readCellOpt();
+    return { $$type: 'JettonBurn' as const, queryId: _queryId, amount: _amount, responseDestination: _responseDestination, customPayload: _customPayload };
+}
+
+export function loadGetterTupleJettonBurn(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _responseDestination = source.readAddressOpt();
+    const _customPayload = source.readCellOpt();
+    return { $$type: 'JettonBurn' as const, queryId: _queryId, amount: _amount, responseDestination: _responseDestination, customPayload: _customPayload };
+}
+
+export function storeTupleJettonBurn(source: JettonBurn) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.responseDestination);
+    builder.writeCell(source.customPayload);
+    return builder.build();
+}
+
+export function dictValueParserJettonBurn(): DictionaryValue<JettonBurn> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonBurn(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonBurn(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonBurnNotification = {
+    $$type: 'JettonBurnNotification';
+    queryId: bigint;
+    amount: bigint;
+    sender: Address;
+    responseDestination: Address | null;
+}
+
+export function storeJettonBurnNotification(src: JettonBurnNotification) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(2078119902, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.sender);
+        b_0.storeAddress(src.responseDestination);
+    };
+}
+
+export function loadJettonBurnNotification(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 2078119902) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _sender = sc_0.loadAddress();
+    const _responseDestination = sc_0.loadMaybeAddress();
+    return { $$type: 'JettonBurnNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination };
+}
+
+export function loadTupleJettonBurnNotification(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    return { $$type: 'JettonBurnNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination };
+}
+
+export function loadGetterTupleJettonBurnNotification(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    return { $$type: 'JettonBurnNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination };
+}
+
+export function storeTupleJettonBurnNotification(source: JettonBurnNotification) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.sender);
+    builder.writeAddress(source.responseDestination);
+    return builder.build();
+}
+
+export function dictValueParserJettonBurnNotification(): DictionaryValue<JettonBurnNotification> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonBurnNotification(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonBurnNotification(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonExcesses = {
+    $$type: 'JettonExcesses';
+    queryId: bigint;
+}
+
+export function storeJettonExcesses(src: JettonExcesses) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(3576854235, 32);
+        b_0.storeUint(src.queryId, 64);
+    };
+}
+
+export function loadJettonExcesses(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 3576854235) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    return { $$type: 'JettonExcesses' as const, queryId: _queryId };
+}
+
+export function loadTupleJettonExcesses(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    return { $$type: 'JettonExcesses' as const, queryId: _queryId };
+}
+
+export function loadGetterTupleJettonExcesses(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    return { $$type: 'JettonExcesses' as const, queryId: _queryId };
+}
+
+export function storeTupleJettonExcesses(source: JettonExcesses) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    return builder.build();
+}
+
+export function dictValueParserJettonExcesses(): DictionaryValue<JettonExcesses> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonExcesses(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonExcesses(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type ProvideWalletAddress = {
+    $$type: 'ProvideWalletAddress';
+    queryId: bigint;
+    ownerAddress: Address;
+    includeAddress: boolean;
+}
+
+export function storeProvideWalletAddress(src: ProvideWalletAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(745978227, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeAddress(src.ownerAddress);
+        b_0.storeBit(src.includeAddress);
+    };
+}
+
+export function loadProvideWalletAddress(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 745978227) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _ownerAddress = sc_0.loadAddress();
+    const _includeAddress = sc_0.loadBit();
+    return { $$type: 'ProvideWalletAddress' as const, queryId: _queryId, ownerAddress: _ownerAddress, includeAddress: _includeAddress };
+}
+
+export function loadTupleProvideWalletAddress(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _ownerAddress = source.readAddress();
+    const _includeAddress = source.readBoolean();
+    return { $$type: 'ProvideWalletAddress' as const, queryId: _queryId, ownerAddress: _ownerAddress, includeAddress: _includeAddress };
+}
+
+export function loadGetterTupleProvideWalletAddress(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _ownerAddress = source.readAddress();
+    const _includeAddress = source.readBoolean();
+    return { $$type: 'ProvideWalletAddress' as const, queryId: _queryId, ownerAddress: _ownerAddress, includeAddress: _includeAddress };
+}
+
+export function storeTupleProvideWalletAddress(source: ProvideWalletAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeAddress(source.ownerAddress);
+    builder.writeBoolean(source.includeAddress);
+    return builder.build();
+}
+
+export function dictValueParserProvideWalletAddress(): DictionaryValue<ProvideWalletAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeProvideWalletAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadProvideWalletAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type TakeWalletAddress = {
+    $$type: 'TakeWalletAddress';
+    queryId: bigint;
+    walletAddress: Address;
+    ownerAddress: Cell | null;
+}
+
+export function storeTakeWalletAddress(src: TakeWalletAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(3513996288, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeAddress(src.walletAddress);
+        if (src.ownerAddress !== null && src.ownerAddress !== undefined) { b_0.storeBit(true).storeRef(src.ownerAddress); } else { b_0.storeBit(false); }
+    };
+}
+
+export function loadTakeWalletAddress(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 3513996288) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _walletAddress = sc_0.loadAddress();
+    const _ownerAddress = sc_0.loadBit() ? sc_0.loadRef() : null;
+    return { $$type: 'TakeWalletAddress' as const, queryId: _queryId, walletAddress: _walletAddress, ownerAddress: _ownerAddress };
+}
+
+export function loadTupleTakeWalletAddress(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _walletAddress = source.readAddress();
+    const _ownerAddress = source.readCellOpt();
+    return { $$type: 'TakeWalletAddress' as const, queryId: _queryId, walletAddress: _walletAddress, ownerAddress: _ownerAddress };
+}
+
+export function loadGetterTupleTakeWalletAddress(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _walletAddress = source.readAddress();
+    const _ownerAddress = source.readCellOpt();
+    return { $$type: 'TakeWalletAddress' as const, queryId: _queryId, walletAddress: _walletAddress, ownerAddress: _ownerAddress };
+}
+
+export function storeTupleTakeWalletAddress(source: TakeWalletAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeAddress(source.walletAddress);
+    builder.writeCell(source.ownerAddress);
+    return builder.build();
+}
+
+export function dictValueParserTakeWalletAddress(): DictionaryValue<TakeWalletAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeTakeWalletAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadTakeWalletAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type Mint = {
+    $$type: 'Mint';
+    queryId: bigint;
+    receiver: Address;
+    mintMessage: JettonTransferInternal;
+}
+
+export function storeMint(src: Mint) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(1680571655, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeAddress(src.receiver);
+        const b_1 = new Builder();
+        b_1.store(storeJettonTransferInternal(src.mintMessage));
+        b_0.storeRef(b_1.endCell());
+    };
+}
+
+export function loadMint(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 1680571655) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _receiver = sc_0.loadAddress();
+    const sc_1 = sc_0.loadRef().beginParse();
+    const _mintMessage = loadJettonTransferInternal(sc_1);
+    return { $$type: 'Mint' as const, queryId: _queryId, receiver: _receiver, mintMessage: _mintMessage };
+}
+
+export function loadTupleMint(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _receiver = source.readAddress();
+    const _mintMessage = loadTupleJettonTransferInternal(source);
+    return { $$type: 'Mint' as const, queryId: _queryId, receiver: _receiver, mintMessage: _mintMessage };
+}
+
+export function loadGetterTupleMint(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _receiver = source.readAddress();
+    const _mintMessage = loadGetterTupleJettonTransferInternal(source);
+    return { $$type: 'Mint' as const, queryId: _queryId, receiver: _receiver, mintMessage: _mintMessage };
+}
+
+export function storeTupleMint(source: Mint) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeAddress(source.receiver);
+    builder.writeTuple(storeTupleJettonTransferInternal(source.mintMessage));
+    return builder.build();
+}
+
+export function dictValueParserMint(): DictionaryValue<Mint> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeMint(src)).endCell());
+        },
+        parse: (src) => {
+            return loadMint(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type CloseMinting = {
+    $$type: 'CloseMinting';
+}
+
+export function storeCloseMinting(src: CloseMinting) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(22, 32);
+    };
+}
+
+export function loadCloseMinting(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 22) { throw Error('Invalid prefix'); }
+    return { $$type: 'CloseMinting' as const };
+}
+
+export function loadTupleCloseMinting(source: TupleReader) {
+    return { $$type: 'CloseMinting' as const };
+}
+
+export function loadGetterTupleCloseMinting(source: TupleReader) {
+    return { $$type: 'CloseMinting' as const };
+}
+
+export function storeTupleCloseMinting(source: CloseMinting) {
+    const builder = new TupleBuilder();
+    return builder.build();
+}
+
+export function dictValueParserCloseMinting(): DictionaryValue<CloseMinting> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeCloseMinting(src)).endCell());
+        },
+        parse: (src) => {
+            return loadCloseMinting(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type ChangeOwner = {
+    $$type: 'ChangeOwner';
+    queryId: bigint;
+    newOwner: Address;
+}
+
+export function storeChangeOwner(src: ChangeOwner) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(3, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeAddress(src.newOwner);
+    };
+}
+
+export function loadChangeOwner(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 3) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _newOwner = sc_0.loadAddress();
+    return { $$type: 'ChangeOwner' as const, queryId: _queryId, newOwner: _newOwner };
+}
+
+export function loadTupleChangeOwner(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _newOwner = source.readAddress();
+    return { $$type: 'ChangeOwner' as const, queryId: _queryId, newOwner: _newOwner };
+}
+
+export function loadGetterTupleChangeOwner(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _newOwner = source.readAddress();
+    return { $$type: 'ChangeOwner' as const, queryId: _queryId, newOwner: _newOwner };
+}
+
+export function storeTupleChangeOwner(source: ChangeOwner) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeAddress(source.newOwner);
+    return builder.build();
+}
+
+export function dictValueParserChangeOwner(): DictionaryValue<ChangeOwner> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeChangeOwner(src)).endCell());
+        },
+        parse: (src) => {
+            return loadChangeOwner(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type ProvideWalletBalance = {
+    $$type: 'ProvideWalletBalance';
+    receiver: Address;
+    includeVerifyInfo: boolean;
+}
+
+export function storeProvideWalletBalance(src: ProvideWalletBalance) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(2059982169, 32);
+        b_0.storeAddress(src.receiver);
+        b_0.storeBit(src.includeVerifyInfo);
+    };
+}
+
+export function loadProvideWalletBalance(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 2059982169) { throw Error('Invalid prefix'); }
+    const _receiver = sc_0.loadAddress();
+    const _includeVerifyInfo = sc_0.loadBit();
+    return { $$type: 'ProvideWalletBalance' as const, receiver: _receiver, includeVerifyInfo: _includeVerifyInfo };
+}
+
+export function loadTupleProvideWalletBalance(source: TupleReader) {
+    const _receiver = source.readAddress();
+    const _includeVerifyInfo = source.readBoolean();
+    return { $$type: 'ProvideWalletBalance' as const, receiver: _receiver, includeVerifyInfo: _includeVerifyInfo };
+}
+
+export function loadGetterTupleProvideWalletBalance(source: TupleReader) {
+    const _receiver = source.readAddress();
+    const _includeVerifyInfo = source.readBoolean();
+    return { $$type: 'ProvideWalletBalance' as const, receiver: _receiver, includeVerifyInfo: _includeVerifyInfo };
+}
+
+export function storeTupleProvideWalletBalance(source: ProvideWalletBalance) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.receiver);
+    builder.writeBoolean(source.includeVerifyInfo);
+    return builder.build();
+}
+
+export function dictValueParserProvideWalletBalance(): DictionaryValue<ProvideWalletBalance> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeProvideWalletBalance(src)).endCell());
+        },
+        parse: (src) => {
+            return loadProvideWalletBalance(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type VerifyInfo = {
+    $$type: 'VerifyInfo';
+    owner: Address;
+    minter: Address;
+    code: Cell;
+}
+
+export function storeVerifyInfo(src: VerifyInfo) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeAddress(src.owner);
+        b_0.storeAddress(src.minter);
+        b_0.storeRef(src.code);
+    };
+}
+
+export function loadVerifyInfo(slice: Slice) {
+    const sc_0 = slice;
+    const _owner = sc_0.loadAddress();
+    const _minter = sc_0.loadAddress();
+    const _code = sc_0.loadRef();
+    return { $$type: 'VerifyInfo' as const, owner: _owner, minter: _minter, code: _code };
+}
+
+export function loadTupleVerifyInfo(source: TupleReader) {
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _code = source.readCell();
+    return { $$type: 'VerifyInfo' as const, owner: _owner, minter: _minter, code: _code };
+}
+
+export function loadGetterTupleVerifyInfo(source: TupleReader) {
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _code = source.readCell();
+    return { $$type: 'VerifyInfo' as const, owner: _owner, minter: _minter, code: _code };
+}
+
+export function storeTupleVerifyInfo(source: VerifyInfo) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.owner);
+    builder.writeAddress(source.minter);
+    builder.writeCell(source.code);
+    return builder.build();
+}
+
+export function dictValueParserVerifyInfo(): DictionaryValue<VerifyInfo> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeVerifyInfo(src)).endCell());
+        },
+        parse: (src) => {
+            return loadVerifyInfo(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type TakeWalletBalance = {
+    $$type: 'TakeWalletBalance';
+    balance: bigint;
+    verifyInfo: VerifyInfo | null;
+}
+
+export function storeTakeWalletBalance(src: TakeWalletBalance) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(3396861378, 32);
+        b_0.storeCoins(src.balance);
+        if (src.verifyInfo !== null && src.verifyInfo !== undefined) { b_0.storeBit(true); b_0.store(storeVerifyInfo(src.verifyInfo)); } else { b_0.storeBit(false); }
+    };
+}
+
+export function loadTakeWalletBalance(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 3396861378) { throw Error('Invalid prefix'); }
+    const _balance = sc_0.loadCoins();
+    const _verifyInfo = sc_0.loadBit() ? loadVerifyInfo(sc_0) : null;
+    return { $$type: 'TakeWalletBalance' as const, balance: _balance, verifyInfo: _verifyInfo };
+}
+
+export function loadTupleTakeWalletBalance(source: TupleReader) {
+    const _balance = source.readBigNumber();
+    const _verifyInfo_p = source.readTupleOpt();
+    const _verifyInfo = _verifyInfo_p ? loadTupleVerifyInfo(_verifyInfo_p) : null;
+    return { $$type: 'TakeWalletBalance' as const, balance: _balance, verifyInfo: _verifyInfo };
+}
+
+export function loadGetterTupleTakeWalletBalance(source: TupleReader) {
+    const _balance = source.readBigNumber();
+    const _verifyInfo_p = source.readTupleOpt();
+    const _verifyInfo = _verifyInfo_p ? loadTupleVerifyInfo(_verifyInfo_p) : null;
+    return { $$type: 'TakeWalletBalance' as const, balance: _balance, verifyInfo: _verifyInfo };
+}
+
+export function storeTupleTakeWalletBalance(source: TakeWalletBalance) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.balance);
+    if (source.verifyInfo !== null && source.verifyInfo !== undefined) {
+        builder.writeTuple(storeTupleVerifyInfo(source.verifyInfo));
+    } else {
+        builder.writeTuple(null);
+    }
+    return builder.build();
+}
+
+export function dictValueParserTakeWalletBalance(): DictionaryValue<TakeWalletBalance> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeTakeWalletBalance(src)).endCell());
+        },
+        parse: (src) => {
+            return loadTakeWalletBalance(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type ClaimTON = {
+    $$type: 'ClaimTON';
+    receiver: Address;
+}
+
+export function storeClaimTON(src: ClaimTON) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(60010958, 32);
+        b_0.storeAddress(src.receiver);
+    };
+}
+
+export function loadClaimTON(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 60010958) { throw Error('Invalid prefix'); }
+    const _receiver = sc_0.loadAddress();
+    return { $$type: 'ClaimTON' as const, receiver: _receiver };
+}
+
+export function loadTupleClaimTON(source: TupleReader) {
+    const _receiver = source.readAddress();
+    return { $$type: 'ClaimTON' as const, receiver: _receiver };
+}
+
+export function loadGetterTupleClaimTON(source: TupleReader) {
+    const _receiver = source.readAddress();
+    return { $$type: 'ClaimTON' as const, receiver: _receiver };
+}
+
+export function storeTupleClaimTON(source: ClaimTON) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.receiver);
+    return builder.build();
+}
+
+export function dictValueParserClaimTON(): DictionaryValue<ClaimTON> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeClaimTON(src)).endCell());
+        },
+        parse: (src) => {
+            return loadClaimTON(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type SliceBitsAndRefs = {
+    $$type: 'SliceBitsAndRefs';
+    bits: bigint;
+    refs: bigint;
+}
+
+export function storeSliceBitsAndRefs(src: SliceBitsAndRefs) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.bits, 257);
+        b_0.storeInt(src.refs, 257);
+    };
+}
+
+export function loadSliceBitsAndRefs(slice: Slice) {
+    const sc_0 = slice;
+    const _bits = sc_0.loadIntBig(257);
+    const _refs = sc_0.loadIntBig(257);
+    return { $$type: 'SliceBitsAndRefs' as const, bits: _bits, refs: _refs };
+}
+
+export function loadTupleSliceBitsAndRefs(source: TupleReader) {
+    const _bits = source.readBigNumber();
+    const _refs = source.readBigNumber();
+    return { $$type: 'SliceBitsAndRefs' as const, bits: _bits, refs: _refs };
+}
+
+export function loadGetterTupleSliceBitsAndRefs(source: TupleReader) {
+    const _bits = source.readBigNumber();
+    const _refs = source.readBigNumber();
+    return { $$type: 'SliceBitsAndRefs' as const, bits: _bits, refs: _refs };
+}
+
+export function storeTupleSliceBitsAndRefs(source: SliceBitsAndRefs) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.bits);
+    builder.writeNumber(source.refs);
+    return builder.build();
+}
+
+export function dictValueParserSliceBitsAndRefs(): DictionaryValue<SliceBitsAndRefs> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeSliceBitsAndRefs(src)).endCell());
+        },
+        parse: (src) => {
+            return loadSliceBitsAndRefs(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonMinterState = {
+    $$type: 'JettonMinterState';
+    totalSupply: bigint;
+    mintable: boolean;
+    adminAddress: Address;
+    jettonContent: Cell;
+    jettonWalletCode: Cell;
+}
+
+export function storeJettonMinterState(src: JettonMinterState) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeCoins(src.totalSupply);
+        b_0.storeBit(src.mintable);
+        b_0.storeAddress(src.adminAddress);
+        b_0.storeRef(src.jettonContent);
+        b_0.storeRef(src.jettonWalletCode);
+    };
+}
+
+export function loadJettonMinterState(slice: Slice) {
+    const sc_0 = slice;
+    const _totalSupply = sc_0.loadCoins();
+    const _mintable = sc_0.loadBit();
+    const _adminAddress = sc_0.loadAddress();
+    const _jettonContent = sc_0.loadRef();
+    const _jettonWalletCode = sc_0.loadRef();
+    return { $$type: 'JettonMinterState' as const, totalSupply: _totalSupply, mintable: _mintable, adminAddress: _adminAddress, jettonContent: _jettonContent, jettonWalletCode: _jettonWalletCode };
+}
+
+export function loadTupleJettonMinterState(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _mintable = source.readBoolean();
+    const _adminAddress = source.readAddress();
+    const _jettonContent = source.readCell();
+    const _jettonWalletCode = source.readCell();
+    return { $$type: 'JettonMinterState' as const, totalSupply: _totalSupply, mintable: _mintable, adminAddress: _adminAddress, jettonContent: _jettonContent, jettonWalletCode: _jettonWalletCode };
+}
+
+export function loadGetterTupleJettonMinterState(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _mintable = source.readBoolean();
+    const _adminAddress = source.readAddress();
+    const _jettonContent = source.readCell();
+    const _jettonWalletCode = source.readCell();
+    return { $$type: 'JettonMinterState' as const, totalSupply: _totalSupply, mintable: _mintable, adminAddress: _adminAddress, jettonContent: _jettonContent, jettonWalletCode: _jettonWalletCode };
+}
+
+export function storeTupleJettonMinterState(source: JettonMinterState) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.totalSupply);
+    builder.writeBoolean(source.mintable);
+    builder.writeAddress(source.adminAddress);
+    builder.writeCell(source.jettonContent);
+    builder.writeCell(source.jettonWalletCode);
+    return builder.build();
+}
+
+export function dictValueParserJettonMinterState(): DictionaryValue<JettonMinterState> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonMinterState(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonMinterState(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonMinter$Data = {
+    $$type: 'JettonMinter$Data';
+    totalSupply: bigint;
+    owner: Address;
+    jettonContent: Cell;
+    mintable: boolean;
+}
+
+export function storeJettonMinter$Data(src: JettonMinter$Data) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeCoins(src.totalSupply);
+        b_0.storeAddress(src.owner);
+        b_0.storeRef(src.jettonContent);
+        b_0.storeBit(src.mintable);
+    };
+}
+
+export function loadJettonMinter$Data(slice: Slice) {
+    const sc_0 = slice;
+    const _totalSupply = sc_0.loadCoins();
+    const _owner = sc_0.loadAddress();
+    const _jettonContent = sc_0.loadRef();
+    const _mintable = sc_0.loadBit();
+    return { $$type: 'JettonMinter$Data' as const, totalSupply: _totalSupply, owner: _owner, jettonContent: _jettonContent, mintable: _mintable };
+}
+
+export function loadTupleJettonMinter$Data(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _owner = source.readAddress();
+    const _jettonContent = source.readCell();
+    const _mintable = source.readBoolean();
+    return { $$type: 'JettonMinter$Data' as const, totalSupply: _totalSupply, owner: _owner, jettonContent: _jettonContent, mintable: _mintable };
+}
+
+export function loadGetterTupleJettonMinter$Data(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _owner = source.readAddress();
+    const _jettonContent = source.readCell();
+    const _mintable = source.readBoolean();
+    return { $$type: 'JettonMinter$Data' as const, totalSupply: _totalSupply, owner: _owner, jettonContent: _jettonContent, mintable: _mintable };
+}
+
+export function storeTupleJettonMinter$Data(source: JettonMinter$Data) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.totalSupply);
+    builder.writeAddress(source.owner);
+    builder.writeCell(source.jettonContent);
+    builder.writeBoolean(source.mintable);
+    return builder.build();
+}
+
+export function dictValueParserJettonMinter$Data(): DictionaryValue<JettonMinter$Data> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonMinter$Data(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonMinter$Data(src.loadRef().beginParse());
+        }
+    }
+}
+
+ type JettonMinter_init_args = {
+    $$type: 'JettonMinter_init_args';
+    totalSupply: bigint;
+    owner: Address;
+    jettonContent: Cell;
+    mintable: boolean;
+}
+
+function initJettonMinter_init_args(src: JettonMinter_init_args) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeCoins(src.totalSupply);
+        b_0.storeAddress(src.owner);
+        b_0.storeRef(src.jettonContent);
+        b_0.storeBit(src.mintable);
+    };
+}
+
+async function JettonMinter_init(totalSupply: bigint, owner: Address, jettonContent: Cell, mintable: boolean) {
+    const __code = Cell.fromHex('b5ee9c7241022101000980000228ff008e88f4a413f4bcf2c80bed5320e303ed43d9010402038e66020301a5adbcf6a2687d007d206a69002a98360a2a81fc143844642a90ad678b2c678b00fd0164b82c907c80117c802d6bb280ebb2c101009a64658be587e587e5ffe5ffb8fc8200643a00e581096503e5ffe4e83620c00c0133af16f6a2687d007d206a69002a98360a442a32102a32a83622c00c02f83001d072d721d200d200fa4021103450666f04f86102f862ed44d0fa00fa40d4d20055306c14058e39038020d7217021d749c21f9430d31f01de8210178d4519ba8e1cd33ffa00596c2112a15023c855305043fa0201cf1612ccca00c9ed54e05f05e003d70d1ff2e0822182102c76b973bae302218210642b7d07ba050702fc6c51d33ffa40d20055203320fa4430c0008eb120f8287088c855215acf1658cf1601fa02c920f90022f9005ad76501d76582020134c8cb17cb0fcb0fcbffcbff71f90400916de20395c801cf16c992306de2c88210d173540001cb1f12cb3f58206e95307001cb019e830958cb0a01206ef2d08001cbffe2f400c9f842700c060038804043137fc8cf8580ca00cf8440ce01fa02806acf40f400c901fb0004e6e3022182107bdd97debae30221c0048e27313302d33fd4596c218123fff8425240c705f2f45003c855305043fa0201cf1612ccca00c9ed54e021c0038e2631d33ffa40596c218123fff84213c70512f2f44003c855305043fa0201cf1612ccca00c9ed54e03520c016e3026c22820b93b1ceba080b1f2001fe31d33ffa40d401d0d31f018210178d4519baf2e081d33ffa00fa4020d70b01c30093fa40019472d7216de201fa005155151443303610681067550437378123fff8425290c705f2f48200caee2bf2f425f404016e913091d1e2f8416f24820092fd82089896802ca045405236fa40fa0071d721fa00fa00306c6170f83a13a00902fc801e814e2070f838a081290470f836aa00a012bcf2f45182a05520707f50a8805008c855508210178d45195007cb1f15cb3f5003fa0201cf1601206e9430cf848092cf16e201fa0201cf16c902f8287088c855215acf1658cf1601fa02c91057104710371027103510245f41f90001f9005ad76501d76582020134c8cb170c0a007ecb0fcb0fcbffcbff71f9040003c8cf8580ca0012cccccf884008cbff01fa028069cf40cf8634f400c901fb004003c855305043fa0201cf1612ccca00c9ed5403e231d33ffa00fa4020d70b01c30093fa40019472d7216de214433034f842fa4402f8287088c855215acf1658cf1601fa02c920f90022f9005ad76501d76582020134c8cb17cb0fcb0fcbffcbff71f9040081287b02c00097206ef2d08012ba93303170e2f2f414a1216eb3923330e30d40030c1d1e022cff008e88f4a413f4bcf2c80bed53208e8130e1ed43d90d0e0033a65ec0bb51343e903e903e8015481b04fe0a95185014901b0d20049401d072d721d200d200fa4021103450666f04f86102f862ed44d0fa40fa40fa0055206c1304e30202d70d1ff2e0822182100f8a7ea5bae302218210178d4519bae3022182107ac8d559ba0f10141900b2028020d7217021d749c21f9430d31f01de208210178d4519ba8e1930d33ffa00596c2113a0c855205acf1658cf1601fa02c9ed54e082107bdd97deba8e18d33ffa00596c2113a0c855205acf1658cf1601fa02c9ed54e05f0401fe31d33ffa00fa4020d70b01c30093fa40019472d7216de201f404fa0051661615144330323622fa4430f2d08a8123fff8425280c705f2f45183a181093e21c2fff2f428f404016e913091d1e2f8416f2429b8a4541432817d7106fa40fa0071d721fa00fa00306c6170f83a12a85280a0801e814e2070f838a081290470f8361101feaa008208989680a0a0bcf2f450437080407f294813509cc855508210178d45195007cb1f15cb3f5003fa0201cf1601206e9430cf848092cf16e201fa0201cf16c9543167f82ac855215acf1658cf1601fa02c9105810381045102410235f41f90001f9005ad76501d76582020134c8cb17cb0fcb0fcbffcbff71f9040003c812015c89cf16ca0012cccccf884008cbff01fa028069cf40cf8634f400c901fb0002c855205acf1658cf1601fa02c9ed541300016001f831d33ffa00fa4020d70b01c30093fa40019472d7216de201fa00515515144330365183a0532770f82ac855215acf1658cf1601fa02c9f842fa44315920f90022f9005ad76501d76582020134c8cb17cb0fcb0fcbffcbff71f90400206ef2d08001ba9a8123fff84229c705f2f4dff8416f2421f8276f1021a12ec2001503fa8e5c5531fa40fa0071d721fa00fa00306c6170f83a52b0a012a17170284813507ac8553082107362d09c5005cb1f13cb3f01fa0201cf1601cf16c92804103b4655441359c8cf8580ca00cf8440ce01fa02806acf40f400c901fb0006503396107e106b6c82e28208989680b60972fb02256eb39320c2009170e2e30f02161718007205206ef2d0808100827003c8018210d53276db58cb1fcb3fc9102410374170441359c8cf8580ca00cf8440ce01fa02806acf40f400c901fb0000045b33001ec855205acf1658cf1601fa02c9ed5402fe8e6331fa40d200596d339931f82a4330126f0301926c22e259c8598210ca77fdc25003cb1f01fa02216eb38e137f01ca0001206ef2d0806f235acf1658cf16cc947032ca00e2c90170804043137fc8cf8580ca00cf8440ce01fa02806acf40f400c901fb00e0218210595f07bcbae302333302820b93b1cebae3025bf2c0821a1c01c831d33ffa0020d70b01c30093fa40019472d7216de201f404553030338123fff8425250c705f2f45155a181093e21c2fff2f4f8416f2443305230fa40fa0071d721fa00fa00306c6170f83a817d71811a2c70f836aa0012a012bcf2f47080405413757f061b00a0c8553082107bdd97de5005cb1f13cb3f01fa0201cf1601206e9430cf848092cf16e2c9254744441359c8cf8580ca00cf8440ce01fa02806acf40f400c901fb0002c855205acf1658cf1601fa02c9ed54006cfa4001318123fff84213c70512f2f482089896808010fb027083066d40037fc8cf8580ca00cf8440ce01fa02806acf40f400c901fb00006601206ef2d08003c8018210d53276db58cb1fcb3fc913707080425044c8cf8580ca00cf8440ce01fa02806acf40f400c901fb000022c855305043fa0201cf1612ccca00c9ed54006230338123fff8425240c705f2f470f842c8cf8508ce70cf0b6ec98042fb004330c855305043fa0201cf1612ccca00c9ed5400808e3901fa4001318123fff84213c70512f2f482089896808010fb027f01708306036d5033c8cf8580ca00cf8440ce01fa02806acf40f400c901fb00e05bf2c08284fd9f0f');
+    const builder = beginCell();
+    initJettonMinter_init_args({ $$type: 'JettonMinter_init_args', totalSupply, owner, jettonContent, mintable })(builder);
+    const __data = builder.endCell();
+    return { code: __code, data: __data };
+}
+
+export const JettonMinter_errors = {
+    2: { message: "Stack underflow" },
+    3: { message: "Stack overflow" },
+    4: { message: "Integer overflow" },
+    5: { message: "Integer out of expected range" },
+    6: { message: "Invalid opcode" },
+    7: { message: "Type check error" },
+    8: { message: "Cell overflow" },
+    9: { message: "Cell underflow" },
+    10: { message: "Dictionary error" },
+    11: { message: "'Unknown' error" },
+    12: { message: "Fatal error" },
+    13: { message: "Out of gas error" },
+    14: { message: "Virtualization error" },
+    32: { message: "Action list is invalid" },
+    33: { message: "Action list is too long" },
+    34: { message: "Action is invalid or not supported" },
+    35: { message: "Invalid source address in outbound message" },
+    36: { message: "Invalid destination address in outbound message" },
+    37: { message: "Not enough Toncoin" },
+    38: { message: "Not enough extra currencies" },
+    39: { message: "Outbound message does not fit into a cell after rewriting" },
+    40: { message: "Cannot process a message" },
+    41: { message: "Library reference is null" },
+    42: { message: "Library change action error" },
+    43: { message: "Exceeded maximum number of cells in the library or the maximum depth of the Merkle tree" },
+    50: { message: "Account state size exceeded limits" },
+    128: { message: "Null reference exception" },
+    129: { message: "Invalid serialization prefix" },
+    130: { message: "Invalid incoming message" },
+    131: { message: "Constraints error" },
+    132: { message: "Access denied" },
+    133: { message: "Contract stopped" },
+    134: { message: "Invalid argument" },
+    135: { message: "Code of a contract was not found" },
+    136: { message: "Invalid standard address" },
+    138: { message: "Not a basechain address" },
+    2366: { message: "Incorrect balance after send" },
+    9215: { message: "Incorrect sender" },
+    10363: { message: "Unauthorized burn" },
+    32113: { message: "Insufficient amount of TON attached" },
+    37629: { message: "Insufficient gas for mint" },
+    51950: { message: "Mint is closed" },
+} as const
+
+export const JettonMinter_errors_backward = {
+    "Stack underflow": 2,
+    "Stack overflow": 3,
+    "Integer overflow": 4,
+    "Integer out of expected range": 5,
+    "Invalid opcode": 6,
+    "Type check error": 7,
+    "Cell overflow": 8,
+    "Cell underflow": 9,
+    "Dictionary error": 10,
+    "'Unknown' error": 11,
+    "Fatal error": 12,
+    "Out of gas error": 13,
+    "Virtualization error": 14,
+    "Action list is invalid": 32,
+    "Action list is too long": 33,
+    "Action is invalid or not supported": 34,
+    "Invalid source address in outbound message": 35,
+    "Invalid destination address in outbound message": 36,
+    "Not enough Toncoin": 37,
+    "Not enough extra currencies": 38,
+    "Outbound message does not fit into a cell after rewriting": 39,
+    "Cannot process a message": 40,
+    "Library reference is null": 41,
+    "Library change action error": 42,
+    "Exceeded maximum number of cells in the library or the maximum depth of the Merkle tree": 43,
+    "Account state size exceeded limits": 50,
+    "Null reference exception": 128,
+    "Invalid serialization prefix": 129,
+    "Invalid incoming message": 130,
+    "Constraints error": 131,
+    "Access denied": 132,
+    "Contract stopped": 133,
+    "Invalid argument": 134,
+    "Code of a contract was not found": 135,
+    "Invalid standard address": 136,
+    "Not a basechain address": 138,
+    "Incorrect balance after send": 2366,
+    "Incorrect sender": 9215,
+    "Unauthorized burn": 10363,
+    "Insufficient amount of TON attached": 32113,
+    "Insufficient gas for mint": 37629,
+    "Mint is closed": 51950,
+} as const
+
+const JettonMinter_types: ABIType[] = [
+    {"name":"DataSize","header":null,"fields":[{"name":"cells","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"bits","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"refs","type":{"kind":"simple","type":"int","optional":false,"format":257}}]},
+    {"name":"SignedBundle","header":null,"fields":[{"name":"signature","type":{"kind":"simple","type":"fixed-bytes","optional":false,"format":64}},{"name":"signedData","type":{"kind":"simple","type":"slice","optional":false,"format":"remainder"}}]},
+    {"name":"StateInit","header":null,"fields":[{"name":"code","type":{"kind":"simple","type":"cell","optional":false}},{"name":"data","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"Context","header":null,"fields":[{"name":"bounceable","type":{"kind":"simple","type":"bool","optional":false}},{"name":"sender","type":{"kind":"simple","type":"address","optional":false}},{"name":"value","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"raw","type":{"kind":"simple","type":"slice","optional":false}}]},
+    {"name":"SendParameters","header":null,"fields":[{"name":"mode","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"body","type":{"kind":"simple","type":"cell","optional":true}},{"name":"code","type":{"kind":"simple","type":"cell","optional":true}},{"name":"data","type":{"kind":"simple","type":"cell","optional":true}},{"name":"value","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"to","type":{"kind":"simple","type":"address","optional":false}},{"name":"bounce","type":{"kind":"simple","type":"bool","optional":false}}]},
+    {"name":"MessageParameters","header":null,"fields":[{"name":"mode","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"body","type":{"kind":"simple","type":"cell","optional":true}},{"name":"value","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"to","type":{"kind":"simple","type":"address","optional":false}},{"name":"bounce","type":{"kind":"simple","type":"bool","optional":false}}]},
+    {"name":"DeployParameters","header":null,"fields":[{"name":"mode","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"body","type":{"kind":"simple","type":"cell","optional":true}},{"name":"value","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"bounce","type":{"kind":"simple","type":"bool","optional":false}},{"name":"init","type":{"kind":"simple","type":"StateInit","optional":false}}]},
+    {"name":"StdAddress","header":null,"fields":[{"name":"workchain","type":{"kind":"simple","type":"int","optional":false,"format":8}},{"name":"address","type":{"kind":"simple","type":"uint","optional":false,"format":256}}]},
+    {"name":"VarAddress","header":null,"fields":[{"name":"workchain","type":{"kind":"simple","type":"int","optional":false,"format":32}},{"name":"address","type":{"kind":"simple","type":"slice","optional":false}}]},
+    {"name":"BasechainAddress","header":null,"fields":[{"name":"hash","type":{"kind":"simple","type":"int","optional":true,"format":257}}]},
+    {"name":"JettonWallet$Data","header":null,"fields":[{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"minter","type":{"kind":"simple","type":"address","optional":false}},{"name":"balance","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}}]},
+    {"name":"JettonData","header":null,"fields":[{"name":"totalSupply","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"mintable","type":{"kind":"simple","type":"bool","optional":false}},{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"content","type":{"kind":"simple","type":"cell","optional":false}},{"name":"jettonWalletCode","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"JettonWalletData","header":null,"fields":[{"name":"balance","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"minter","type":{"kind":"simple","type":"address","optional":false}},{"name":"code","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"MaybeAddress","header":null,"fields":[{"name":"address","type":{"kind":"simple","type":"address","optional":true}}]},
+    {"name":"JettonUpdateContent","header":4,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"content","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"JettonTransfer","header":260734629,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"destination","type":{"kind":"simple","type":"address","optional":false}},{"name":"responseDestination","type":{"kind":"simple","type":"address","optional":true}},{"name":"customPayload","type":{"kind":"simple","type":"cell","optional":true}},{"name":"forwardTonAmount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"forwardPayload","type":{"kind":"simple","type":"slice","optional":false,"format":"remainder"}}]},
+    {"name":"JettonTransferInternal","header":395134233,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"sender","type":{"kind":"simple","type":"address","optional":false}},{"name":"responseDestination","type":{"kind":"simple","type":"address","optional":true}},{"name":"forwardTonAmount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"forwardPayload","type":{"kind":"simple","type":"slice","optional":false,"format":"remainder"}}]},
+    {"name":"JettonNotification","header":1935855772,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"sender","type":{"kind":"simple","type":"address","optional":false}},{"name":"forwardPayload","type":{"kind":"simple","type":"slice","optional":false,"format":"remainder"}}]},
+    {"name":"JettonBurn","header":1499400124,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"responseDestination","type":{"kind":"simple","type":"address","optional":true}},{"name":"customPayload","type":{"kind":"simple","type":"cell","optional":true}}]},
+    {"name":"JettonBurnNotification","header":2078119902,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"sender","type":{"kind":"simple","type":"address","optional":false}},{"name":"responseDestination","type":{"kind":"simple","type":"address","optional":true}}]},
+    {"name":"JettonExcesses","header":3576854235,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}}]},
+    {"name":"ProvideWalletAddress","header":745978227,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"ownerAddress","type":{"kind":"simple","type":"address","optional":false}},{"name":"includeAddress","type":{"kind":"simple","type":"bool","optional":false}}]},
+    {"name":"TakeWalletAddress","header":3513996288,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"walletAddress","type":{"kind":"simple","type":"address","optional":false}},{"name":"ownerAddress","type":{"kind":"simple","type":"cell","optional":true}}]},
+    {"name":"Mint","header":1680571655,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"receiver","type":{"kind":"simple","type":"address","optional":false}},{"name":"mintMessage","type":{"kind":"simple","type":"JettonTransferInternal","optional":false}}]},
+    {"name":"CloseMinting","header":22,"fields":[]},
+    {"name":"ChangeOwner","header":3,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"newOwner","type":{"kind":"simple","type":"address","optional":false}}]},
+    {"name":"ProvideWalletBalance","header":2059982169,"fields":[{"name":"receiver","type":{"kind":"simple","type":"address","optional":false}},{"name":"includeVerifyInfo","type":{"kind":"simple","type":"bool","optional":false}}]},
+    {"name":"VerifyInfo","header":null,"fields":[{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"minter","type":{"kind":"simple","type":"address","optional":false}},{"name":"code","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"TakeWalletBalance","header":3396861378,"fields":[{"name":"balance","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"verifyInfo","type":{"kind":"simple","type":"VerifyInfo","optional":true}}]},
+    {"name":"ClaimTON","header":60010958,"fields":[{"name":"receiver","type":{"kind":"simple","type":"address","optional":false}}]},
+    {"name":"SliceBitsAndRefs","header":null,"fields":[{"name":"bits","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"refs","type":{"kind":"simple","type":"int","optional":false,"format":257}}]},
+    {"name":"JettonMinterState","header":null,"fields":[{"name":"totalSupply","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"mintable","type":{"kind":"simple","type":"bool","optional":false}},{"name":"adminAddress","type":{"kind":"simple","type":"address","optional":false}},{"name":"jettonContent","type":{"kind":"simple","type":"cell","optional":false}},{"name":"jettonWalletCode","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"JettonMinter$Data","header":null,"fields":[{"name":"totalSupply","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"jettonContent","type":{"kind":"simple","type":"cell","optional":false}},{"name":"mintable","type":{"kind":"simple","type":"bool","optional":false}}]},
+]
+
+const JettonMinter_opcodes = {
+    "JettonUpdateContent": 4,
+    "JettonTransfer": 260734629,
+    "JettonTransferInternal": 395134233,
+    "JettonNotification": 1935855772,
+    "JettonBurn": 1499400124,
+    "JettonBurnNotification": 2078119902,
+    "JettonExcesses": 3576854235,
+    "ProvideWalletAddress": 745978227,
+    "TakeWalletAddress": 3513996288,
+    "Mint": 1680571655,
+    "CloseMinting": 22,
+    "ChangeOwner": 3,
+    "ProvideWalletBalance": 2059982169,
+    "TakeWalletBalance": 3396861378,
+    "ClaimTON": 60010958,
+}
+
+const JettonMinter_getters: ABIGetter[] = [
+    {"name":"get_jetton_data","methodId":106029,"arguments":[],"returnType":{"kind":"simple","type":"JettonMinterState","optional":false}},
+    {"name":"get_wallet_address","methodId":103289,"arguments":[{"name":"ownerAddress","type":{"kind":"simple","type":"address","optional":false}}],"returnType":{"kind":"simple","type":"address","optional":false}},
+]
+
+export const JettonMinter_getterMapping: { [key: string]: string } = {
+    'get_jetton_data': 'getGetJettonData',
+    'get_wallet_address': 'getGetWalletAddress',
+}
+
+const JettonMinter_receivers: ABIReceiver[] = [
+    {"receiver":"internal","message":{"kind":"typed","type":"ProvideWalletAddress"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"Mint"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"JettonBurnNotification"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"JettonUpdateContent"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"ChangeOwner"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"CloseMinting"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"ClaimTON"}},
+]
+
+export const gasForBurn = 6700n;
+export const gasForTransfer = 10500n;
+export const minTonsForStorage = 10000000n;
+export const Basechain = 0n;
+export const walletStateInitCells = 30n;
+export const walletStateInitBits = 20000n;
+
+export class JettonMinter implements Contract {
+    
+    public static readonly storageReserve = 0n;
+    public static readonly errors = JettonMinter_errors_backward;
+    public static readonly opcodes = JettonMinter_opcodes;
+    
+    static async init(totalSupply: bigint, owner: Address, jettonContent: Cell, mintable: boolean) {
+        return await JettonMinter_init(totalSupply, owner, jettonContent, mintable);
+    }
+    
+    static async fromInit(totalSupply: bigint, owner: Address, jettonContent: Cell, mintable: boolean) {
+        const __gen_init = await JettonMinter_init(totalSupply, owner, jettonContent, mintable);
+        const address = contractAddress(0, __gen_init);
+        return new JettonMinter(address, __gen_init);
+    }
+    
+    static fromAddress(address: Address) {
+        return new JettonMinter(address);
+    }
+    
+    readonly address: Address; 
+    readonly init?: { code: Cell, data: Cell };
+    readonly abi: ContractABI = {
+        types:  JettonMinter_types,
+        getters: JettonMinter_getters,
+        receivers: JettonMinter_receivers,
+        errors: JettonMinter_errors,
+    };
+    
+    constructor(address: Address, init?: { code: Cell, data: Cell }) {
+        this.address = address;
+        this.init = init;
+    }
+    
+    async send(provider: ContractProvider, via: Sender, args: { value: bigint, bounce?: boolean| null | undefined }, message: ProvideWalletAddress | Mint | JettonBurnNotification | JettonUpdateContent | ChangeOwner | CloseMinting | ClaimTON) {
+        
+        let body: Cell | null = null;
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'ProvideWalletAddress') {
+            body = beginCell().store(storeProvideWalletAddress(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'Mint') {
+            body = beginCell().store(storeMint(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'JettonBurnNotification') {
+            body = beginCell().store(storeJettonBurnNotification(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'JettonUpdateContent') {
+            body = beginCell().store(storeJettonUpdateContent(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'ChangeOwner') {
+            body = beginCell().store(storeChangeOwner(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'CloseMinting') {
+            body = beginCell().store(storeCloseMinting(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'ClaimTON') {
+            body = beginCell().store(storeClaimTON(message)).endCell();
+        }
+        if (body === null) { throw new Error('Invalid message type'); }
+        
+        await provider.internal(via, { ...args, body: body });
+        
+    }
+    
+    async getGetJettonData(provider: ContractProvider) {
+        const builder = new TupleBuilder();
+        const source = (await provider.get('get_jetton_data', builder.build())).stack;
+        const result = loadGetterTupleJettonMinterState(source);
+        return result;
+    }
+    
+    async getGetWalletAddress(provider: ContractProvider, ownerAddress: Address) {
+        const builder = new TupleBuilder();
+        builder.writeAddress(ownerAddress);
+        const source = (await provider.get('get_wallet_address', builder.build())).stack;
+        const result = source.readAddress();
+        return result;
+    }
+    
+}

--- a/wrappers/TestJetton_JettonWallet.ts
+++ b/wrappers/TestJetton_JettonWallet.ts
@@ -1,0 +1,2230 @@
+import {
+    Cell,
+    Slice,
+    Address,
+    Builder,
+    beginCell,
+    ComputeError,
+    TupleItem,
+    TupleReader,
+    Dictionary,
+    contractAddress,
+    address,
+    ContractProvider,
+    Sender,
+    Contract,
+    ContractABI,
+    ABIType,
+    ABIGetter,
+    ABIReceiver,
+    TupleBuilder,
+    DictionaryValue
+} from '@ton/core';
+
+export type DataSize = {
+    $$type: 'DataSize';
+    cells: bigint;
+    bits: bigint;
+    refs: bigint;
+}
+
+export function storeDataSize(src: DataSize) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.cells, 257);
+        b_0.storeInt(src.bits, 257);
+        b_0.storeInt(src.refs, 257);
+    };
+}
+
+export function loadDataSize(slice: Slice) {
+    const sc_0 = slice;
+    const _cells = sc_0.loadIntBig(257);
+    const _bits = sc_0.loadIntBig(257);
+    const _refs = sc_0.loadIntBig(257);
+    return { $$type: 'DataSize' as const, cells: _cells, bits: _bits, refs: _refs };
+}
+
+export function loadTupleDataSize(source: TupleReader) {
+    const _cells = source.readBigNumber();
+    const _bits = source.readBigNumber();
+    const _refs = source.readBigNumber();
+    return { $$type: 'DataSize' as const, cells: _cells, bits: _bits, refs: _refs };
+}
+
+export function loadGetterTupleDataSize(source: TupleReader) {
+    const _cells = source.readBigNumber();
+    const _bits = source.readBigNumber();
+    const _refs = source.readBigNumber();
+    return { $$type: 'DataSize' as const, cells: _cells, bits: _bits, refs: _refs };
+}
+
+export function storeTupleDataSize(source: DataSize) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.cells);
+    builder.writeNumber(source.bits);
+    builder.writeNumber(source.refs);
+    return builder.build();
+}
+
+export function dictValueParserDataSize(): DictionaryValue<DataSize> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeDataSize(src)).endCell());
+        },
+        parse: (src) => {
+            return loadDataSize(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type SignedBundle = {
+    $$type: 'SignedBundle';
+    signature: Buffer;
+    signedData: Slice;
+}
+
+export function storeSignedBundle(src: SignedBundle) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeBuffer(src.signature);
+        b_0.storeBuilder(src.signedData.asBuilder());
+    };
+}
+
+export function loadSignedBundle(slice: Slice) {
+    const sc_0 = slice;
+    const _signature = sc_0.loadBuffer(64);
+    const _signedData = sc_0;
+    return { $$type: 'SignedBundle' as const, signature: _signature, signedData: _signedData };
+}
+
+export function loadTupleSignedBundle(source: TupleReader) {
+    const _signature = source.readBuffer();
+    const _signedData = source.readCell().asSlice();
+    return { $$type: 'SignedBundle' as const, signature: _signature, signedData: _signedData };
+}
+
+export function loadGetterTupleSignedBundle(source: TupleReader) {
+    const _signature = source.readBuffer();
+    const _signedData = source.readCell().asSlice();
+    return { $$type: 'SignedBundle' as const, signature: _signature, signedData: _signedData };
+}
+
+export function storeTupleSignedBundle(source: SignedBundle) {
+    const builder = new TupleBuilder();
+    builder.writeBuffer(source.signature);
+    builder.writeSlice(source.signedData.asCell());
+    return builder.build();
+}
+
+export function dictValueParserSignedBundle(): DictionaryValue<SignedBundle> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeSignedBundle(src)).endCell());
+        },
+        parse: (src) => {
+            return loadSignedBundle(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type StateInit = {
+    $$type: 'StateInit';
+    code: Cell;
+    data: Cell;
+}
+
+export function storeStateInit(src: StateInit) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeRef(src.code);
+        b_0.storeRef(src.data);
+    };
+}
+
+export function loadStateInit(slice: Slice) {
+    const sc_0 = slice;
+    const _code = sc_0.loadRef();
+    const _data = sc_0.loadRef();
+    return { $$type: 'StateInit' as const, code: _code, data: _data };
+}
+
+export function loadTupleStateInit(source: TupleReader) {
+    const _code = source.readCell();
+    const _data = source.readCell();
+    return { $$type: 'StateInit' as const, code: _code, data: _data };
+}
+
+export function loadGetterTupleStateInit(source: TupleReader) {
+    const _code = source.readCell();
+    const _data = source.readCell();
+    return { $$type: 'StateInit' as const, code: _code, data: _data };
+}
+
+export function storeTupleStateInit(source: StateInit) {
+    const builder = new TupleBuilder();
+    builder.writeCell(source.code);
+    builder.writeCell(source.data);
+    return builder.build();
+}
+
+export function dictValueParserStateInit(): DictionaryValue<StateInit> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeStateInit(src)).endCell());
+        },
+        parse: (src) => {
+            return loadStateInit(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type Context = {
+    $$type: 'Context';
+    bounceable: boolean;
+    sender: Address;
+    value: bigint;
+    raw: Slice;
+}
+
+export function storeContext(src: Context) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeBit(src.bounceable);
+        b_0.storeAddress(src.sender);
+        b_0.storeInt(src.value, 257);
+        b_0.storeRef(src.raw.asCell());
+    };
+}
+
+export function loadContext(slice: Slice) {
+    const sc_0 = slice;
+    const _bounceable = sc_0.loadBit();
+    const _sender = sc_0.loadAddress();
+    const _value = sc_0.loadIntBig(257);
+    const _raw = sc_0.loadRef().asSlice();
+    return { $$type: 'Context' as const, bounceable: _bounceable, sender: _sender, value: _value, raw: _raw };
+}
+
+export function loadTupleContext(source: TupleReader) {
+    const _bounceable = source.readBoolean();
+    const _sender = source.readAddress();
+    const _value = source.readBigNumber();
+    const _raw = source.readCell().asSlice();
+    return { $$type: 'Context' as const, bounceable: _bounceable, sender: _sender, value: _value, raw: _raw };
+}
+
+export function loadGetterTupleContext(source: TupleReader) {
+    const _bounceable = source.readBoolean();
+    const _sender = source.readAddress();
+    const _value = source.readBigNumber();
+    const _raw = source.readCell().asSlice();
+    return { $$type: 'Context' as const, bounceable: _bounceable, sender: _sender, value: _value, raw: _raw };
+}
+
+export function storeTupleContext(source: Context) {
+    const builder = new TupleBuilder();
+    builder.writeBoolean(source.bounceable);
+    builder.writeAddress(source.sender);
+    builder.writeNumber(source.value);
+    builder.writeSlice(source.raw.asCell());
+    return builder.build();
+}
+
+export function dictValueParserContext(): DictionaryValue<Context> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeContext(src)).endCell());
+        },
+        parse: (src) => {
+            return loadContext(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type SendParameters = {
+    $$type: 'SendParameters';
+    mode: bigint;
+    body: Cell | null;
+    code: Cell | null;
+    data: Cell | null;
+    value: bigint;
+    to: Address;
+    bounce: boolean;
+}
+
+export function storeSendParameters(src: SendParameters) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.mode, 257);
+        if (src.body !== null && src.body !== undefined) { b_0.storeBit(true).storeRef(src.body); } else { b_0.storeBit(false); }
+        if (src.code !== null && src.code !== undefined) { b_0.storeBit(true).storeRef(src.code); } else { b_0.storeBit(false); }
+        if (src.data !== null && src.data !== undefined) { b_0.storeBit(true).storeRef(src.data); } else { b_0.storeBit(false); }
+        b_0.storeInt(src.value, 257);
+        b_0.storeAddress(src.to);
+        b_0.storeBit(src.bounce);
+    };
+}
+
+export function loadSendParameters(slice: Slice) {
+    const sc_0 = slice;
+    const _mode = sc_0.loadIntBig(257);
+    const _body = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _code = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _data = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _value = sc_0.loadIntBig(257);
+    const _to = sc_0.loadAddress();
+    const _bounce = sc_0.loadBit();
+    return { $$type: 'SendParameters' as const, mode: _mode, body: _body, code: _code, data: _data, value: _value, to: _to, bounce: _bounce };
+}
+
+export function loadTupleSendParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _code = source.readCellOpt();
+    const _data = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _to = source.readAddress();
+    const _bounce = source.readBoolean();
+    return { $$type: 'SendParameters' as const, mode: _mode, body: _body, code: _code, data: _data, value: _value, to: _to, bounce: _bounce };
+}
+
+export function loadGetterTupleSendParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _code = source.readCellOpt();
+    const _data = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _to = source.readAddress();
+    const _bounce = source.readBoolean();
+    return { $$type: 'SendParameters' as const, mode: _mode, body: _body, code: _code, data: _data, value: _value, to: _to, bounce: _bounce };
+}
+
+export function storeTupleSendParameters(source: SendParameters) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.mode);
+    builder.writeCell(source.body);
+    builder.writeCell(source.code);
+    builder.writeCell(source.data);
+    builder.writeNumber(source.value);
+    builder.writeAddress(source.to);
+    builder.writeBoolean(source.bounce);
+    return builder.build();
+}
+
+export function dictValueParserSendParameters(): DictionaryValue<SendParameters> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeSendParameters(src)).endCell());
+        },
+        parse: (src) => {
+            return loadSendParameters(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type MessageParameters = {
+    $$type: 'MessageParameters';
+    mode: bigint;
+    body: Cell | null;
+    value: bigint;
+    to: Address;
+    bounce: boolean;
+}
+
+export function storeMessageParameters(src: MessageParameters) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.mode, 257);
+        if (src.body !== null && src.body !== undefined) { b_0.storeBit(true).storeRef(src.body); } else { b_0.storeBit(false); }
+        b_0.storeInt(src.value, 257);
+        b_0.storeAddress(src.to);
+        b_0.storeBit(src.bounce);
+    };
+}
+
+export function loadMessageParameters(slice: Slice) {
+    const sc_0 = slice;
+    const _mode = sc_0.loadIntBig(257);
+    const _body = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _value = sc_0.loadIntBig(257);
+    const _to = sc_0.loadAddress();
+    const _bounce = sc_0.loadBit();
+    return { $$type: 'MessageParameters' as const, mode: _mode, body: _body, value: _value, to: _to, bounce: _bounce };
+}
+
+export function loadTupleMessageParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _to = source.readAddress();
+    const _bounce = source.readBoolean();
+    return { $$type: 'MessageParameters' as const, mode: _mode, body: _body, value: _value, to: _to, bounce: _bounce };
+}
+
+export function loadGetterTupleMessageParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _to = source.readAddress();
+    const _bounce = source.readBoolean();
+    return { $$type: 'MessageParameters' as const, mode: _mode, body: _body, value: _value, to: _to, bounce: _bounce };
+}
+
+export function storeTupleMessageParameters(source: MessageParameters) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.mode);
+    builder.writeCell(source.body);
+    builder.writeNumber(source.value);
+    builder.writeAddress(source.to);
+    builder.writeBoolean(source.bounce);
+    return builder.build();
+}
+
+export function dictValueParserMessageParameters(): DictionaryValue<MessageParameters> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeMessageParameters(src)).endCell());
+        },
+        parse: (src) => {
+            return loadMessageParameters(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type DeployParameters = {
+    $$type: 'DeployParameters';
+    mode: bigint;
+    body: Cell | null;
+    value: bigint;
+    bounce: boolean;
+    init: StateInit;
+}
+
+export function storeDeployParameters(src: DeployParameters) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.mode, 257);
+        if (src.body !== null && src.body !== undefined) { b_0.storeBit(true).storeRef(src.body); } else { b_0.storeBit(false); }
+        b_0.storeInt(src.value, 257);
+        b_0.storeBit(src.bounce);
+        b_0.store(storeStateInit(src.init));
+    };
+}
+
+export function loadDeployParameters(slice: Slice) {
+    const sc_0 = slice;
+    const _mode = sc_0.loadIntBig(257);
+    const _body = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _value = sc_0.loadIntBig(257);
+    const _bounce = sc_0.loadBit();
+    const _init = loadStateInit(sc_0);
+    return { $$type: 'DeployParameters' as const, mode: _mode, body: _body, value: _value, bounce: _bounce, init: _init };
+}
+
+export function loadTupleDeployParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _bounce = source.readBoolean();
+    const _init = loadTupleStateInit(source);
+    return { $$type: 'DeployParameters' as const, mode: _mode, body: _body, value: _value, bounce: _bounce, init: _init };
+}
+
+export function loadGetterTupleDeployParameters(source: TupleReader) {
+    const _mode = source.readBigNumber();
+    const _body = source.readCellOpt();
+    const _value = source.readBigNumber();
+    const _bounce = source.readBoolean();
+    const _init = loadGetterTupleStateInit(source);
+    return { $$type: 'DeployParameters' as const, mode: _mode, body: _body, value: _value, bounce: _bounce, init: _init };
+}
+
+export function storeTupleDeployParameters(source: DeployParameters) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.mode);
+    builder.writeCell(source.body);
+    builder.writeNumber(source.value);
+    builder.writeBoolean(source.bounce);
+    builder.writeTuple(storeTupleStateInit(source.init));
+    return builder.build();
+}
+
+export function dictValueParserDeployParameters(): DictionaryValue<DeployParameters> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeDeployParameters(src)).endCell());
+        },
+        parse: (src) => {
+            return loadDeployParameters(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type StdAddress = {
+    $$type: 'StdAddress';
+    workchain: bigint;
+    address: bigint;
+}
+
+export function storeStdAddress(src: StdAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.workchain, 8);
+        b_0.storeUint(src.address, 256);
+    };
+}
+
+export function loadStdAddress(slice: Slice) {
+    const sc_0 = slice;
+    const _workchain = sc_0.loadIntBig(8);
+    const _address = sc_0.loadUintBig(256);
+    return { $$type: 'StdAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function loadTupleStdAddress(source: TupleReader) {
+    const _workchain = source.readBigNumber();
+    const _address = source.readBigNumber();
+    return { $$type: 'StdAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function loadGetterTupleStdAddress(source: TupleReader) {
+    const _workchain = source.readBigNumber();
+    const _address = source.readBigNumber();
+    return { $$type: 'StdAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function storeTupleStdAddress(source: StdAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.workchain);
+    builder.writeNumber(source.address);
+    return builder.build();
+}
+
+export function dictValueParserStdAddress(): DictionaryValue<StdAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeStdAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadStdAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type VarAddress = {
+    $$type: 'VarAddress';
+    workchain: bigint;
+    address: Slice;
+}
+
+export function storeVarAddress(src: VarAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.workchain, 32);
+        b_0.storeRef(src.address.asCell());
+    };
+}
+
+export function loadVarAddress(slice: Slice) {
+    const sc_0 = slice;
+    const _workchain = sc_0.loadIntBig(32);
+    const _address = sc_0.loadRef().asSlice();
+    return { $$type: 'VarAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function loadTupleVarAddress(source: TupleReader) {
+    const _workchain = source.readBigNumber();
+    const _address = source.readCell().asSlice();
+    return { $$type: 'VarAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function loadGetterTupleVarAddress(source: TupleReader) {
+    const _workchain = source.readBigNumber();
+    const _address = source.readCell().asSlice();
+    return { $$type: 'VarAddress' as const, workchain: _workchain, address: _address };
+}
+
+export function storeTupleVarAddress(source: VarAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.workchain);
+    builder.writeSlice(source.address.asCell());
+    return builder.build();
+}
+
+export function dictValueParserVarAddress(): DictionaryValue<VarAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeVarAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadVarAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type BasechainAddress = {
+    $$type: 'BasechainAddress';
+    hash: bigint | null;
+}
+
+export function storeBasechainAddress(src: BasechainAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        if (src.hash !== null && src.hash !== undefined) { b_0.storeBit(true).storeInt(src.hash, 257); } else { b_0.storeBit(false); }
+    };
+}
+
+export function loadBasechainAddress(slice: Slice) {
+    const sc_0 = slice;
+    const _hash = sc_0.loadBit() ? sc_0.loadIntBig(257) : null;
+    return { $$type: 'BasechainAddress' as const, hash: _hash };
+}
+
+export function loadTupleBasechainAddress(source: TupleReader) {
+    const _hash = source.readBigNumberOpt();
+    return { $$type: 'BasechainAddress' as const, hash: _hash };
+}
+
+export function loadGetterTupleBasechainAddress(source: TupleReader) {
+    const _hash = source.readBigNumberOpt();
+    return { $$type: 'BasechainAddress' as const, hash: _hash };
+}
+
+export function storeTupleBasechainAddress(source: BasechainAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.hash);
+    return builder.build();
+}
+
+export function dictValueParserBasechainAddress(): DictionaryValue<BasechainAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeBasechainAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadBasechainAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonWallet$Data = {
+    $$type: 'JettonWallet$Data';
+    owner: Address;
+    minter: Address;
+    balance: bigint;
+}
+
+export function storeJettonWallet$Data(src: JettonWallet$Data) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeAddress(src.owner);
+        b_0.storeAddress(src.minter);
+        b_0.storeCoins(src.balance);
+    };
+}
+
+export function loadJettonWallet$Data(slice: Slice) {
+    const sc_0 = slice;
+    const _owner = sc_0.loadAddress();
+    const _minter = sc_0.loadAddress();
+    const _balance = sc_0.loadCoins();
+    return { $$type: 'JettonWallet$Data' as const, owner: _owner, minter: _minter, balance: _balance };
+}
+
+export function loadTupleJettonWallet$Data(source: TupleReader) {
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _balance = source.readBigNumber();
+    return { $$type: 'JettonWallet$Data' as const, owner: _owner, minter: _minter, balance: _balance };
+}
+
+export function loadGetterTupleJettonWallet$Data(source: TupleReader) {
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _balance = source.readBigNumber();
+    return { $$type: 'JettonWallet$Data' as const, owner: _owner, minter: _minter, balance: _balance };
+}
+
+export function storeTupleJettonWallet$Data(source: JettonWallet$Data) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.owner);
+    builder.writeAddress(source.minter);
+    builder.writeNumber(source.balance);
+    return builder.build();
+}
+
+export function dictValueParserJettonWallet$Data(): DictionaryValue<JettonWallet$Data> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonWallet$Data(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonWallet$Data(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonData = {
+    $$type: 'JettonData';
+    totalSupply: bigint;
+    mintable: boolean;
+    owner: Address;
+    content: Cell;
+    jettonWalletCode: Cell;
+}
+
+export function storeJettonData(src: JettonData) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.totalSupply, 257);
+        b_0.storeBit(src.mintable);
+        b_0.storeAddress(src.owner);
+        b_0.storeRef(src.content);
+        b_0.storeRef(src.jettonWalletCode);
+    };
+}
+
+export function loadJettonData(slice: Slice) {
+    const sc_0 = slice;
+    const _totalSupply = sc_0.loadIntBig(257);
+    const _mintable = sc_0.loadBit();
+    const _owner = sc_0.loadAddress();
+    const _content = sc_0.loadRef();
+    const _jettonWalletCode = sc_0.loadRef();
+    return { $$type: 'JettonData' as const, totalSupply: _totalSupply, mintable: _mintable, owner: _owner, content: _content, jettonWalletCode: _jettonWalletCode };
+}
+
+export function loadTupleJettonData(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _mintable = source.readBoolean();
+    const _owner = source.readAddress();
+    const _content = source.readCell();
+    const _jettonWalletCode = source.readCell();
+    return { $$type: 'JettonData' as const, totalSupply: _totalSupply, mintable: _mintable, owner: _owner, content: _content, jettonWalletCode: _jettonWalletCode };
+}
+
+export function loadGetterTupleJettonData(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _mintable = source.readBoolean();
+    const _owner = source.readAddress();
+    const _content = source.readCell();
+    const _jettonWalletCode = source.readCell();
+    return { $$type: 'JettonData' as const, totalSupply: _totalSupply, mintable: _mintable, owner: _owner, content: _content, jettonWalletCode: _jettonWalletCode };
+}
+
+export function storeTupleJettonData(source: JettonData) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.totalSupply);
+    builder.writeBoolean(source.mintable);
+    builder.writeAddress(source.owner);
+    builder.writeCell(source.content);
+    builder.writeCell(source.jettonWalletCode);
+    return builder.build();
+}
+
+export function dictValueParserJettonData(): DictionaryValue<JettonData> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonData(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonData(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonWalletData = {
+    $$type: 'JettonWalletData';
+    balance: bigint;
+    owner: Address;
+    minter: Address;
+    code: Cell;
+}
+
+export function storeJettonWalletData(src: JettonWalletData) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.balance, 257);
+        b_0.storeAddress(src.owner);
+        b_0.storeAddress(src.minter);
+        b_0.storeRef(src.code);
+    };
+}
+
+export function loadJettonWalletData(slice: Slice) {
+    const sc_0 = slice;
+    const _balance = sc_0.loadIntBig(257);
+    const _owner = sc_0.loadAddress();
+    const _minter = sc_0.loadAddress();
+    const _code = sc_0.loadRef();
+    return { $$type: 'JettonWalletData' as const, balance: _balance, owner: _owner, minter: _minter, code: _code };
+}
+
+export function loadTupleJettonWalletData(source: TupleReader) {
+    const _balance = source.readBigNumber();
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _code = source.readCell();
+    return { $$type: 'JettonWalletData' as const, balance: _balance, owner: _owner, minter: _minter, code: _code };
+}
+
+export function loadGetterTupleJettonWalletData(source: TupleReader) {
+    const _balance = source.readBigNumber();
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _code = source.readCell();
+    return { $$type: 'JettonWalletData' as const, balance: _balance, owner: _owner, minter: _minter, code: _code };
+}
+
+export function storeTupleJettonWalletData(source: JettonWalletData) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.balance);
+    builder.writeAddress(source.owner);
+    builder.writeAddress(source.minter);
+    builder.writeCell(source.code);
+    return builder.build();
+}
+
+export function dictValueParserJettonWalletData(): DictionaryValue<JettonWalletData> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonWalletData(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonWalletData(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type MaybeAddress = {
+    $$type: 'MaybeAddress';
+    address: Address | null;
+}
+
+export function storeMaybeAddress(src: MaybeAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeAddress(src.address);
+    };
+}
+
+export function loadMaybeAddress(slice: Slice) {
+    const sc_0 = slice;
+    const _address = sc_0.loadMaybeAddress();
+    return { $$type: 'MaybeAddress' as const, address: _address };
+}
+
+export function loadTupleMaybeAddress(source: TupleReader) {
+    const _address = source.readAddressOpt();
+    return { $$type: 'MaybeAddress' as const, address: _address };
+}
+
+export function loadGetterTupleMaybeAddress(source: TupleReader) {
+    const _address = source.readAddressOpt();
+    return { $$type: 'MaybeAddress' as const, address: _address };
+}
+
+export function storeTupleMaybeAddress(source: MaybeAddress) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.address);
+    return builder.build();
+}
+
+export function dictValueParserMaybeAddress(): DictionaryValue<MaybeAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeMaybeAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadMaybeAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonUpdateContent = {
+    $$type: 'JettonUpdateContent';
+    queryId: bigint;
+    content: Cell;
+}
+
+export function storeJettonUpdateContent(src: JettonUpdateContent) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(4, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeRef(src.content);
+    };
+}
+
+export function loadJettonUpdateContent(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 4) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _content = sc_0.loadRef();
+    return { $$type: 'JettonUpdateContent' as const, queryId: _queryId, content: _content };
+}
+
+export function loadTupleJettonUpdateContent(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _content = source.readCell();
+    return { $$type: 'JettonUpdateContent' as const, queryId: _queryId, content: _content };
+}
+
+export function loadGetterTupleJettonUpdateContent(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _content = source.readCell();
+    return { $$type: 'JettonUpdateContent' as const, queryId: _queryId, content: _content };
+}
+
+export function storeTupleJettonUpdateContent(source: JettonUpdateContent) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeCell(source.content);
+    return builder.build();
+}
+
+export function dictValueParserJettonUpdateContent(): DictionaryValue<JettonUpdateContent> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonUpdateContent(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonUpdateContent(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonTransfer = {
+    $$type: 'JettonTransfer';
+    queryId: bigint;
+    amount: bigint;
+    destination: Address;
+    responseDestination: Address | null;
+    customPayload: Cell | null;
+    forwardTonAmount: bigint;
+    forwardPayload: Slice;
+}
+
+export function storeJettonTransfer(src: JettonTransfer) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(260734629, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.destination);
+        b_0.storeAddress(src.responseDestination);
+        if (src.customPayload !== null && src.customPayload !== undefined) { b_0.storeBit(true).storeRef(src.customPayload); } else { b_0.storeBit(false); }
+        b_0.storeCoins(src.forwardTonAmount);
+        b_0.storeBuilder(src.forwardPayload.asBuilder());
+    };
+}
+
+export function loadJettonTransfer(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 260734629) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _destination = sc_0.loadAddress();
+    const _responseDestination = sc_0.loadMaybeAddress();
+    const _customPayload = sc_0.loadBit() ? sc_0.loadRef() : null;
+    const _forwardTonAmount = sc_0.loadCoins();
+    const _forwardPayload = sc_0;
+    return { $$type: 'JettonTransfer' as const, queryId: _queryId, amount: _amount, destination: _destination, responseDestination: _responseDestination, customPayload: _customPayload, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function loadTupleJettonTransfer(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _destination = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    const _customPayload = source.readCellOpt();
+    const _forwardTonAmount = source.readBigNumber();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonTransfer' as const, queryId: _queryId, amount: _amount, destination: _destination, responseDestination: _responseDestination, customPayload: _customPayload, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function loadGetterTupleJettonTransfer(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _destination = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    const _customPayload = source.readCellOpt();
+    const _forwardTonAmount = source.readBigNumber();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonTransfer' as const, queryId: _queryId, amount: _amount, destination: _destination, responseDestination: _responseDestination, customPayload: _customPayload, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function storeTupleJettonTransfer(source: JettonTransfer) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.destination);
+    builder.writeAddress(source.responseDestination);
+    builder.writeCell(source.customPayload);
+    builder.writeNumber(source.forwardTonAmount);
+    builder.writeSlice(source.forwardPayload.asCell());
+    return builder.build();
+}
+
+export function dictValueParserJettonTransfer(): DictionaryValue<JettonTransfer> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonTransfer(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonTransfer(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonTransferInternal = {
+    $$type: 'JettonTransferInternal';
+    queryId: bigint;
+    amount: bigint;
+    sender: Address;
+    responseDestination: Address | null;
+    forwardTonAmount: bigint;
+    forwardPayload: Slice;
+}
+
+export function storeJettonTransferInternal(src: JettonTransferInternal) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(395134233, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.sender);
+        b_0.storeAddress(src.responseDestination);
+        b_0.storeCoins(src.forwardTonAmount);
+        b_0.storeBuilder(src.forwardPayload.asBuilder());
+    };
+}
+
+export function loadJettonTransferInternal(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 395134233) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _sender = sc_0.loadAddress();
+    const _responseDestination = sc_0.loadMaybeAddress();
+    const _forwardTonAmount = sc_0.loadCoins();
+    const _forwardPayload = sc_0;
+    return { $$type: 'JettonTransferInternal' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function loadTupleJettonTransferInternal(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    const _forwardTonAmount = source.readBigNumber();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonTransferInternal' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function loadGetterTupleJettonTransferInternal(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    const _forwardTonAmount = source.readBigNumber();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonTransferInternal' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination, forwardTonAmount: _forwardTonAmount, forwardPayload: _forwardPayload };
+}
+
+export function storeTupleJettonTransferInternal(source: JettonTransferInternal) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.sender);
+    builder.writeAddress(source.responseDestination);
+    builder.writeNumber(source.forwardTonAmount);
+    builder.writeSlice(source.forwardPayload.asCell());
+    return builder.build();
+}
+
+export function dictValueParserJettonTransferInternal(): DictionaryValue<JettonTransferInternal> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonTransferInternal(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonTransferInternal(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonNotification = {
+    $$type: 'JettonNotification';
+    queryId: bigint;
+    amount: bigint;
+    sender: Address;
+    forwardPayload: Slice;
+}
+
+export function storeJettonNotification(src: JettonNotification) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(1935855772, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.sender);
+        b_0.storeBuilder(src.forwardPayload.asBuilder());
+    };
+}
+
+export function loadJettonNotification(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 1935855772) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _sender = sc_0.loadAddress();
+    const _forwardPayload = sc_0;
+    return { $$type: 'JettonNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, forwardPayload: _forwardPayload };
+}
+
+export function loadTupleJettonNotification(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, forwardPayload: _forwardPayload };
+}
+
+export function loadGetterTupleJettonNotification(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _forwardPayload = source.readCell().asSlice();
+    return { $$type: 'JettonNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, forwardPayload: _forwardPayload };
+}
+
+export function storeTupleJettonNotification(source: JettonNotification) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.sender);
+    builder.writeSlice(source.forwardPayload.asCell());
+    return builder.build();
+}
+
+export function dictValueParserJettonNotification(): DictionaryValue<JettonNotification> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonNotification(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonNotification(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonBurn = {
+    $$type: 'JettonBurn';
+    queryId: bigint;
+    amount: bigint;
+    responseDestination: Address | null;
+    customPayload: Cell | null;
+}
+
+export function storeJettonBurn(src: JettonBurn) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(1499400124, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.responseDestination);
+        if (src.customPayload !== null && src.customPayload !== undefined) { b_0.storeBit(true).storeRef(src.customPayload); } else { b_0.storeBit(false); }
+    };
+}
+
+export function loadJettonBurn(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 1499400124) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _responseDestination = sc_0.loadMaybeAddress();
+    const _customPayload = sc_0.loadBit() ? sc_0.loadRef() : null;
+    return { $$type: 'JettonBurn' as const, queryId: _queryId, amount: _amount, responseDestination: _responseDestination, customPayload: _customPayload };
+}
+
+export function loadTupleJettonBurn(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _responseDestination = source.readAddressOpt();
+    const _customPayload = source.readCellOpt();
+    return { $$type: 'JettonBurn' as const, queryId: _queryId, amount: _amount, responseDestination: _responseDestination, customPayload: _customPayload };
+}
+
+export function loadGetterTupleJettonBurn(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _responseDestination = source.readAddressOpt();
+    const _customPayload = source.readCellOpt();
+    return { $$type: 'JettonBurn' as const, queryId: _queryId, amount: _amount, responseDestination: _responseDestination, customPayload: _customPayload };
+}
+
+export function storeTupleJettonBurn(source: JettonBurn) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.responseDestination);
+    builder.writeCell(source.customPayload);
+    return builder.build();
+}
+
+export function dictValueParserJettonBurn(): DictionaryValue<JettonBurn> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonBurn(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonBurn(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonBurnNotification = {
+    $$type: 'JettonBurnNotification';
+    queryId: bigint;
+    amount: bigint;
+    sender: Address;
+    responseDestination: Address | null;
+}
+
+export function storeJettonBurnNotification(src: JettonBurnNotification) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(2078119902, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeCoins(src.amount);
+        b_0.storeAddress(src.sender);
+        b_0.storeAddress(src.responseDestination);
+    };
+}
+
+export function loadJettonBurnNotification(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 2078119902) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _amount = sc_0.loadCoins();
+    const _sender = sc_0.loadAddress();
+    const _responseDestination = sc_0.loadMaybeAddress();
+    return { $$type: 'JettonBurnNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination };
+}
+
+export function loadTupleJettonBurnNotification(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    return { $$type: 'JettonBurnNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination };
+}
+
+export function loadGetterTupleJettonBurnNotification(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _amount = source.readBigNumber();
+    const _sender = source.readAddress();
+    const _responseDestination = source.readAddressOpt();
+    return { $$type: 'JettonBurnNotification' as const, queryId: _queryId, amount: _amount, sender: _sender, responseDestination: _responseDestination };
+}
+
+export function storeTupleJettonBurnNotification(source: JettonBurnNotification) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeNumber(source.amount);
+    builder.writeAddress(source.sender);
+    builder.writeAddress(source.responseDestination);
+    return builder.build();
+}
+
+export function dictValueParserJettonBurnNotification(): DictionaryValue<JettonBurnNotification> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonBurnNotification(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonBurnNotification(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonExcesses = {
+    $$type: 'JettonExcesses';
+    queryId: bigint;
+}
+
+export function storeJettonExcesses(src: JettonExcesses) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(3576854235, 32);
+        b_0.storeUint(src.queryId, 64);
+    };
+}
+
+export function loadJettonExcesses(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 3576854235) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    return { $$type: 'JettonExcesses' as const, queryId: _queryId };
+}
+
+export function loadTupleJettonExcesses(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    return { $$type: 'JettonExcesses' as const, queryId: _queryId };
+}
+
+export function loadGetterTupleJettonExcesses(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    return { $$type: 'JettonExcesses' as const, queryId: _queryId };
+}
+
+export function storeTupleJettonExcesses(source: JettonExcesses) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    return builder.build();
+}
+
+export function dictValueParserJettonExcesses(): DictionaryValue<JettonExcesses> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonExcesses(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonExcesses(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type ProvideWalletAddress = {
+    $$type: 'ProvideWalletAddress';
+    queryId: bigint;
+    ownerAddress: Address;
+    includeAddress: boolean;
+}
+
+export function storeProvideWalletAddress(src: ProvideWalletAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(745978227, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeAddress(src.ownerAddress);
+        b_0.storeBit(src.includeAddress);
+    };
+}
+
+export function loadProvideWalletAddress(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 745978227) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _ownerAddress = sc_0.loadAddress();
+    const _includeAddress = sc_0.loadBit();
+    return { $$type: 'ProvideWalletAddress' as const, queryId: _queryId, ownerAddress: _ownerAddress, includeAddress: _includeAddress };
+}
+
+export function loadTupleProvideWalletAddress(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _ownerAddress = source.readAddress();
+    const _includeAddress = source.readBoolean();
+    return { $$type: 'ProvideWalletAddress' as const, queryId: _queryId, ownerAddress: _ownerAddress, includeAddress: _includeAddress };
+}
+
+export function loadGetterTupleProvideWalletAddress(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _ownerAddress = source.readAddress();
+    const _includeAddress = source.readBoolean();
+    return { $$type: 'ProvideWalletAddress' as const, queryId: _queryId, ownerAddress: _ownerAddress, includeAddress: _includeAddress };
+}
+
+export function storeTupleProvideWalletAddress(source: ProvideWalletAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeAddress(source.ownerAddress);
+    builder.writeBoolean(source.includeAddress);
+    return builder.build();
+}
+
+export function dictValueParserProvideWalletAddress(): DictionaryValue<ProvideWalletAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeProvideWalletAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadProvideWalletAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type TakeWalletAddress = {
+    $$type: 'TakeWalletAddress';
+    queryId: bigint;
+    walletAddress: Address;
+    ownerAddress: Cell | null;
+}
+
+export function storeTakeWalletAddress(src: TakeWalletAddress) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(3513996288, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeAddress(src.walletAddress);
+        if (src.ownerAddress !== null && src.ownerAddress !== undefined) { b_0.storeBit(true).storeRef(src.ownerAddress); } else { b_0.storeBit(false); }
+    };
+}
+
+export function loadTakeWalletAddress(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 3513996288) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _walletAddress = sc_0.loadAddress();
+    const _ownerAddress = sc_0.loadBit() ? sc_0.loadRef() : null;
+    return { $$type: 'TakeWalletAddress' as const, queryId: _queryId, walletAddress: _walletAddress, ownerAddress: _ownerAddress };
+}
+
+export function loadTupleTakeWalletAddress(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _walletAddress = source.readAddress();
+    const _ownerAddress = source.readCellOpt();
+    return { $$type: 'TakeWalletAddress' as const, queryId: _queryId, walletAddress: _walletAddress, ownerAddress: _ownerAddress };
+}
+
+export function loadGetterTupleTakeWalletAddress(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _walletAddress = source.readAddress();
+    const _ownerAddress = source.readCellOpt();
+    return { $$type: 'TakeWalletAddress' as const, queryId: _queryId, walletAddress: _walletAddress, ownerAddress: _ownerAddress };
+}
+
+export function storeTupleTakeWalletAddress(source: TakeWalletAddress) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeAddress(source.walletAddress);
+    builder.writeCell(source.ownerAddress);
+    return builder.build();
+}
+
+export function dictValueParserTakeWalletAddress(): DictionaryValue<TakeWalletAddress> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeTakeWalletAddress(src)).endCell());
+        },
+        parse: (src) => {
+            return loadTakeWalletAddress(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type Mint = {
+    $$type: 'Mint';
+    queryId: bigint;
+    receiver: Address;
+    mintMessage: JettonTransferInternal;
+}
+
+export function storeMint(src: Mint) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(1680571655, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeAddress(src.receiver);
+        const b_1 = new Builder();
+        b_1.store(storeJettonTransferInternal(src.mintMessage));
+        b_0.storeRef(b_1.endCell());
+    };
+}
+
+export function loadMint(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 1680571655) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _receiver = sc_0.loadAddress();
+    const sc_1 = sc_0.loadRef().beginParse();
+    const _mintMessage = loadJettonTransferInternal(sc_1);
+    return { $$type: 'Mint' as const, queryId: _queryId, receiver: _receiver, mintMessage: _mintMessage };
+}
+
+export function loadTupleMint(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _receiver = source.readAddress();
+    const _mintMessage = loadTupleJettonTransferInternal(source);
+    return { $$type: 'Mint' as const, queryId: _queryId, receiver: _receiver, mintMessage: _mintMessage };
+}
+
+export function loadGetterTupleMint(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _receiver = source.readAddress();
+    const _mintMessage = loadGetterTupleJettonTransferInternal(source);
+    return { $$type: 'Mint' as const, queryId: _queryId, receiver: _receiver, mintMessage: _mintMessage };
+}
+
+export function storeTupleMint(source: Mint) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeAddress(source.receiver);
+    builder.writeTuple(storeTupleJettonTransferInternal(source.mintMessage));
+    return builder.build();
+}
+
+export function dictValueParserMint(): DictionaryValue<Mint> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeMint(src)).endCell());
+        },
+        parse: (src) => {
+            return loadMint(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type CloseMinting = {
+    $$type: 'CloseMinting';
+}
+
+export function storeCloseMinting(src: CloseMinting) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(22, 32);
+    };
+}
+
+export function loadCloseMinting(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 22) { throw Error('Invalid prefix'); }
+    return { $$type: 'CloseMinting' as const };
+}
+
+export function loadTupleCloseMinting(source: TupleReader) {
+    return { $$type: 'CloseMinting' as const };
+}
+
+export function loadGetterTupleCloseMinting(source: TupleReader) {
+    return { $$type: 'CloseMinting' as const };
+}
+
+export function storeTupleCloseMinting(source: CloseMinting) {
+    const builder = new TupleBuilder();
+    return builder.build();
+}
+
+export function dictValueParserCloseMinting(): DictionaryValue<CloseMinting> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeCloseMinting(src)).endCell());
+        },
+        parse: (src) => {
+            return loadCloseMinting(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type ChangeOwner = {
+    $$type: 'ChangeOwner';
+    queryId: bigint;
+    newOwner: Address;
+}
+
+export function storeChangeOwner(src: ChangeOwner) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(3, 32);
+        b_0.storeUint(src.queryId, 64);
+        b_0.storeAddress(src.newOwner);
+    };
+}
+
+export function loadChangeOwner(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 3) { throw Error('Invalid prefix'); }
+    const _queryId = sc_0.loadUintBig(64);
+    const _newOwner = sc_0.loadAddress();
+    return { $$type: 'ChangeOwner' as const, queryId: _queryId, newOwner: _newOwner };
+}
+
+export function loadTupleChangeOwner(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _newOwner = source.readAddress();
+    return { $$type: 'ChangeOwner' as const, queryId: _queryId, newOwner: _newOwner };
+}
+
+export function loadGetterTupleChangeOwner(source: TupleReader) {
+    const _queryId = source.readBigNumber();
+    const _newOwner = source.readAddress();
+    return { $$type: 'ChangeOwner' as const, queryId: _queryId, newOwner: _newOwner };
+}
+
+export function storeTupleChangeOwner(source: ChangeOwner) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.queryId);
+    builder.writeAddress(source.newOwner);
+    return builder.build();
+}
+
+export function dictValueParserChangeOwner(): DictionaryValue<ChangeOwner> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeChangeOwner(src)).endCell());
+        },
+        parse: (src) => {
+            return loadChangeOwner(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type ProvideWalletBalance = {
+    $$type: 'ProvideWalletBalance';
+    receiver: Address;
+    includeVerifyInfo: boolean;
+}
+
+export function storeProvideWalletBalance(src: ProvideWalletBalance) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(2059982169, 32);
+        b_0.storeAddress(src.receiver);
+        b_0.storeBit(src.includeVerifyInfo);
+    };
+}
+
+export function loadProvideWalletBalance(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 2059982169) { throw Error('Invalid prefix'); }
+    const _receiver = sc_0.loadAddress();
+    const _includeVerifyInfo = sc_0.loadBit();
+    return { $$type: 'ProvideWalletBalance' as const, receiver: _receiver, includeVerifyInfo: _includeVerifyInfo };
+}
+
+export function loadTupleProvideWalletBalance(source: TupleReader) {
+    const _receiver = source.readAddress();
+    const _includeVerifyInfo = source.readBoolean();
+    return { $$type: 'ProvideWalletBalance' as const, receiver: _receiver, includeVerifyInfo: _includeVerifyInfo };
+}
+
+export function loadGetterTupleProvideWalletBalance(source: TupleReader) {
+    const _receiver = source.readAddress();
+    const _includeVerifyInfo = source.readBoolean();
+    return { $$type: 'ProvideWalletBalance' as const, receiver: _receiver, includeVerifyInfo: _includeVerifyInfo };
+}
+
+export function storeTupleProvideWalletBalance(source: ProvideWalletBalance) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.receiver);
+    builder.writeBoolean(source.includeVerifyInfo);
+    return builder.build();
+}
+
+export function dictValueParserProvideWalletBalance(): DictionaryValue<ProvideWalletBalance> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeProvideWalletBalance(src)).endCell());
+        },
+        parse: (src) => {
+            return loadProvideWalletBalance(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type VerifyInfo = {
+    $$type: 'VerifyInfo';
+    owner: Address;
+    minter: Address;
+    code: Cell;
+}
+
+export function storeVerifyInfo(src: VerifyInfo) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeAddress(src.owner);
+        b_0.storeAddress(src.minter);
+        b_0.storeRef(src.code);
+    };
+}
+
+export function loadVerifyInfo(slice: Slice) {
+    const sc_0 = slice;
+    const _owner = sc_0.loadAddress();
+    const _minter = sc_0.loadAddress();
+    const _code = sc_0.loadRef();
+    return { $$type: 'VerifyInfo' as const, owner: _owner, minter: _minter, code: _code };
+}
+
+export function loadTupleVerifyInfo(source: TupleReader) {
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _code = source.readCell();
+    return { $$type: 'VerifyInfo' as const, owner: _owner, minter: _minter, code: _code };
+}
+
+export function loadGetterTupleVerifyInfo(source: TupleReader) {
+    const _owner = source.readAddress();
+    const _minter = source.readAddress();
+    const _code = source.readCell();
+    return { $$type: 'VerifyInfo' as const, owner: _owner, minter: _minter, code: _code };
+}
+
+export function storeTupleVerifyInfo(source: VerifyInfo) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.owner);
+    builder.writeAddress(source.minter);
+    builder.writeCell(source.code);
+    return builder.build();
+}
+
+export function dictValueParserVerifyInfo(): DictionaryValue<VerifyInfo> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeVerifyInfo(src)).endCell());
+        },
+        parse: (src) => {
+            return loadVerifyInfo(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type TakeWalletBalance = {
+    $$type: 'TakeWalletBalance';
+    balance: bigint;
+    verifyInfo: VerifyInfo | null;
+}
+
+export function storeTakeWalletBalance(src: TakeWalletBalance) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(3396861378, 32);
+        b_0.storeCoins(src.balance);
+        if (src.verifyInfo !== null && src.verifyInfo !== undefined) { b_0.storeBit(true); b_0.store(storeVerifyInfo(src.verifyInfo)); } else { b_0.storeBit(false); }
+    };
+}
+
+export function loadTakeWalletBalance(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 3396861378) { throw Error('Invalid prefix'); }
+    const _balance = sc_0.loadCoins();
+    const _verifyInfo = sc_0.loadBit() ? loadVerifyInfo(sc_0) : null;
+    return { $$type: 'TakeWalletBalance' as const, balance: _balance, verifyInfo: _verifyInfo };
+}
+
+export function loadTupleTakeWalletBalance(source: TupleReader) {
+    const _balance = source.readBigNumber();
+    const _verifyInfo_p = source.readTupleOpt();
+    const _verifyInfo = _verifyInfo_p ? loadTupleVerifyInfo(_verifyInfo_p) : null;
+    return { $$type: 'TakeWalletBalance' as const, balance: _balance, verifyInfo: _verifyInfo };
+}
+
+export function loadGetterTupleTakeWalletBalance(source: TupleReader) {
+    const _balance = source.readBigNumber();
+    const _verifyInfo_p = source.readTupleOpt();
+    const _verifyInfo = _verifyInfo_p ? loadTupleVerifyInfo(_verifyInfo_p) : null;
+    return { $$type: 'TakeWalletBalance' as const, balance: _balance, verifyInfo: _verifyInfo };
+}
+
+export function storeTupleTakeWalletBalance(source: TakeWalletBalance) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.balance);
+    if (source.verifyInfo !== null && source.verifyInfo !== undefined) {
+        builder.writeTuple(storeTupleVerifyInfo(source.verifyInfo));
+    } else {
+        builder.writeTuple(null);
+    }
+    return builder.build();
+}
+
+export function dictValueParserTakeWalletBalance(): DictionaryValue<TakeWalletBalance> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeTakeWalletBalance(src)).endCell());
+        },
+        parse: (src) => {
+            return loadTakeWalletBalance(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type ClaimTON = {
+    $$type: 'ClaimTON';
+    receiver: Address;
+}
+
+export function storeClaimTON(src: ClaimTON) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeUint(60010958, 32);
+        b_0.storeAddress(src.receiver);
+    };
+}
+
+export function loadClaimTON(slice: Slice) {
+    const sc_0 = slice;
+    if (sc_0.loadUint(32) !== 60010958) { throw Error('Invalid prefix'); }
+    const _receiver = sc_0.loadAddress();
+    return { $$type: 'ClaimTON' as const, receiver: _receiver };
+}
+
+export function loadTupleClaimTON(source: TupleReader) {
+    const _receiver = source.readAddress();
+    return { $$type: 'ClaimTON' as const, receiver: _receiver };
+}
+
+export function loadGetterTupleClaimTON(source: TupleReader) {
+    const _receiver = source.readAddress();
+    return { $$type: 'ClaimTON' as const, receiver: _receiver };
+}
+
+export function storeTupleClaimTON(source: ClaimTON) {
+    const builder = new TupleBuilder();
+    builder.writeAddress(source.receiver);
+    return builder.build();
+}
+
+export function dictValueParserClaimTON(): DictionaryValue<ClaimTON> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeClaimTON(src)).endCell());
+        },
+        parse: (src) => {
+            return loadClaimTON(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type SliceBitsAndRefs = {
+    $$type: 'SliceBitsAndRefs';
+    bits: bigint;
+    refs: bigint;
+}
+
+export function storeSliceBitsAndRefs(src: SliceBitsAndRefs) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeInt(src.bits, 257);
+        b_0.storeInt(src.refs, 257);
+    };
+}
+
+export function loadSliceBitsAndRefs(slice: Slice) {
+    const sc_0 = slice;
+    const _bits = sc_0.loadIntBig(257);
+    const _refs = sc_0.loadIntBig(257);
+    return { $$type: 'SliceBitsAndRefs' as const, bits: _bits, refs: _refs };
+}
+
+export function loadTupleSliceBitsAndRefs(source: TupleReader) {
+    const _bits = source.readBigNumber();
+    const _refs = source.readBigNumber();
+    return { $$type: 'SliceBitsAndRefs' as const, bits: _bits, refs: _refs };
+}
+
+export function loadGetterTupleSliceBitsAndRefs(source: TupleReader) {
+    const _bits = source.readBigNumber();
+    const _refs = source.readBigNumber();
+    return { $$type: 'SliceBitsAndRefs' as const, bits: _bits, refs: _refs };
+}
+
+export function storeTupleSliceBitsAndRefs(source: SliceBitsAndRefs) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.bits);
+    builder.writeNumber(source.refs);
+    return builder.build();
+}
+
+export function dictValueParserSliceBitsAndRefs(): DictionaryValue<SliceBitsAndRefs> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeSliceBitsAndRefs(src)).endCell());
+        },
+        parse: (src) => {
+            return loadSliceBitsAndRefs(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonMinterState = {
+    $$type: 'JettonMinterState';
+    totalSupply: bigint;
+    mintable: boolean;
+    adminAddress: Address;
+    jettonContent: Cell;
+    jettonWalletCode: Cell;
+}
+
+export function storeJettonMinterState(src: JettonMinterState) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeCoins(src.totalSupply);
+        b_0.storeBit(src.mintable);
+        b_0.storeAddress(src.adminAddress);
+        b_0.storeRef(src.jettonContent);
+        b_0.storeRef(src.jettonWalletCode);
+    };
+}
+
+export function loadJettonMinterState(slice: Slice) {
+    const sc_0 = slice;
+    const _totalSupply = sc_0.loadCoins();
+    const _mintable = sc_0.loadBit();
+    const _adminAddress = sc_0.loadAddress();
+    const _jettonContent = sc_0.loadRef();
+    const _jettonWalletCode = sc_0.loadRef();
+    return { $$type: 'JettonMinterState' as const, totalSupply: _totalSupply, mintable: _mintable, adminAddress: _adminAddress, jettonContent: _jettonContent, jettonWalletCode: _jettonWalletCode };
+}
+
+export function loadTupleJettonMinterState(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _mintable = source.readBoolean();
+    const _adminAddress = source.readAddress();
+    const _jettonContent = source.readCell();
+    const _jettonWalletCode = source.readCell();
+    return { $$type: 'JettonMinterState' as const, totalSupply: _totalSupply, mintable: _mintable, adminAddress: _adminAddress, jettonContent: _jettonContent, jettonWalletCode: _jettonWalletCode };
+}
+
+export function loadGetterTupleJettonMinterState(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _mintable = source.readBoolean();
+    const _adminAddress = source.readAddress();
+    const _jettonContent = source.readCell();
+    const _jettonWalletCode = source.readCell();
+    return { $$type: 'JettonMinterState' as const, totalSupply: _totalSupply, mintable: _mintable, adminAddress: _adminAddress, jettonContent: _jettonContent, jettonWalletCode: _jettonWalletCode };
+}
+
+export function storeTupleJettonMinterState(source: JettonMinterState) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.totalSupply);
+    builder.writeBoolean(source.mintable);
+    builder.writeAddress(source.adminAddress);
+    builder.writeCell(source.jettonContent);
+    builder.writeCell(source.jettonWalletCode);
+    return builder.build();
+}
+
+export function dictValueParserJettonMinterState(): DictionaryValue<JettonMinterState> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonMinterState(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonMinterState(src.loadRef().beginParse());
+        }
+    }
+}
+
+export type JettonMinter$Data = {
+    $$type: 'JettonMinter$Data';
+    totalSupply: bigint;
+    owner: Address;
+    jettonContent: Cell;
+    mintable: boolean;
+}
+
+export function storeJettonMinter$Data(src: JettonMinter$Data) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeCoins(src.totalSupply);
+        b_0.storeAddress(src.owner);
+        b_0.storeRef(src.jettonContent);
+        b_0.storeBit(src.mintable);
+    };
+}
+
+export function loadJettonMinter$Data(slice: Slice) {
+    const sc_0 = slice;
+    const _totalSupply = sc_0.loadCoins();
+    const _owner = sc_0.loadAddress();
+    const _jettonContent = sc_0.loadRef();
+    const _mintable = sc_0.loadBit();
+    return { $$type: 'JettonMinter$Data' as const, totalSupply: _totalSupply, owner: _owner, jettonContent: _jettonContent, mintable: _mintable };
+}
+
+export function loadTupleJettonMinter$Data(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _owner = source.readAddress();
+    const _jettonContent = source.readCell();
+    const _mintable = source.readBoolean();
+    return { $$type: 'JettonMinter$Data' as const, totalSupply: _totalSupply, owner: _owner, jettonContent: _jettonContent, mintable: _mintable };
+}
+
+export function loadGetterTupleJettonMinter$Data(source: TupleReader) {
+    const _totalSupply = source.readBigNumber();
+    const _owner = source.readAddress();
+    const _jettonContent = source.readCell();
+    const _mintable = source.readBoolean();
+    return { $$type: 'JettonMinter$Data' as const, totalSupply: _totalSupply, owner: _owner, jettonContent: _jettonContent, mintable: _mintable };
+}
+
+export function storeTupleJettonMinter$Data(source: JettonMinter$Data) {
+    const builder = new TupleBuilder();
+    builder.writeNumber(source.totalSupply);
+    builder.writeAddress(source.owner);
+    builder.writeCell(source.jettonContent);
+    builder.writeBoolean(source.mintable);
+    return builder.build();
+}
+
+export function dictValueParserJettonMinter$Data(): DictionaryValue<JettonMinter$Data> {
+    return {
+        serialize: (src, builder) => {
+            builder.storeRef(beginCell().store(storeJettonMinter$Data(src)).endCell());
+        },
+        parse: (src) => {
+            return loadJettonMinter$Data(src.loadRef().beginParse());
+        }
+    }
+}
+
+ type JettonWallet_init_args = {
+    $$type: 'JettonWallet_init_args';
+    owner: Address;
+    minter: Address;
+    balance: bigint;
+}
+
+function initJettonWallet_init_args(src: JettonWallet_init_args) {
+    return (builder: Builder) => {
+        const b_0 = builder;
+        b_0.storeAddress(src.owner);
+        b_0.storeAddress(src.minter);
+        b_0.storeCoins(src.balance);
+    };
+}
+
+async function JettonWallet_init(owner: Address, minter: Address, balance: bigint) {
+    const __code = Cell.fromHex('b5ee9c72410211010004de00022cff008e88f4a413f4bcf2c80bed53208e8130e1ed43d901020033a65ec0bb51343e903e903e8015481b04fe0a95185014901b0d20049401d072d721d200d200fa4021103450666f04f86102f862ed44d0fa40fa40fa0055206c1304e30202d70d1ff2e0822182100f8a7ea5bae302218210178d4519bae3022182107ac8d559ba0304080d00b2028020d7217021d749c21f9430d31f01de208210178d4519ba8e1930d33ffa00596c2113a0c855205acf1658cf1601fa02c9ed54e082107bdd97deba8e18d33ffa00596c2113a0c855205acf1658cf1601fa02c9ed54e05f0401fe31d33ffa00fa4020d70b01c30093fa40019472d7216de201f404fa0051661615144330323622fa4430f2d08a8123fff8425280c705f2f45183a181093e21c2fff2f428f404016e913091d1e2f8416f2429b8a4541432817d7106fa40fa0071d721fa00fa00306c6170f83a12a85280a0801e814e2070f838a081290470f8360501feaa008208989680a0a0bcf2f450437080407f294813509cc855508210178d45195007cb1f15cb3f5003fa0201cf1601206e9430cf848092cf16e201fa0201cf16c9543167f82ac855215acf1658cf1601fa02c9105810381045102410235f41f90001f9005ad76501d76582020134c8cb17cb0fcb0fcbffcbff71f9040003c806015c89cf16ca0012cccccf884008cbff01fa028069cf40cf8634f400c901fb0002c855205acf1658cf1601fa02c9ed540700016001f831d33ffa00fa4020d70b01c30093fa40019472d7216de201fa00515515144330365183a0532770f82ac855215acf1658cf1601fa02c9f842fa44315920f90022f9005ad76501d76582020134c8cb17cb0fcb0fcbffcbff71f90400206ef2d08001ba9a8123fff84229c705f2f4dff8416f2421f8276f1021a12ec2000903fa8e5c5531fa40fa0071d721fa00fa00306c6170f83a52b0a012a17170284813507ac8553082107362d09c5005cb1f13cb3f01fa0201cf1601cf16c92804103b4655441359c8cf8580ca00cf8440ce01fa02806acf40f400c901fb0006503396107e106b6c82e28208989680b60972fb02256eb39320c2009170e2e30f020a0b0c007205206ef2d0808100827003c8018210d53276db58cb1fcb3fc9102410374170441359c8cf8580ca00cf8440ce01fa02806acf40f400c901fb0000045b33001ec855205acf1658cf1601fa02c9ed5402fe8e6331fa40d200596d339931f82a4330126f0301926c22e259c8598210ca77fdc25003cb1f01fa02216eb38e137f01ca0001206ef2d0806f235acf1658cf16cc947032ca00e2c90170804043137fc8cf8580ca00cf8440ce01fa02806acf40f400c901fb00e0218210595f07bcbae302333302820b93b1cebae3025bf2c0820e1001c831d33ffa0020d70b01c30093fa40019472d7216de201f404553030338123fff8425250c705f2f45155a181093e21c2fff2f4f8416f2443305230fa40fa0071d721fa00fa00306c6170f83a817d71811a2c70f836aa0012a012bcf2f47080405413757f060f00a0c8553082107bdd97de5005cb1f13cb3f01fa0201cf1601206e9430cf848092cf16e2c9254744441359c8cf8580ca00cf8440ce01fa02806acf40f400c901fb0002c855205acf1658cf1601fa02c9ed54006cfa4001318123fff84213c70512f2f482089896808010fb027083066d40037fc8cf8580ca00cf8440ce01fa02806acf40f400c901fb0076d0ae71');
+    const builder = beginCell();
+    initJettonWallet_init_args({ $$type: 'JettonWallet_init_args', owner, minter, balance })(builder);
+    const __data = builder.endCell();
+    return { code: __code, data: __data };
+}
+
+export const JettonWallet_errors = {
+    2: { message: "Stack underflow" },
+    3: { message: "Stack overflow" },
+    4: { message: "Integer overflow" },
+    5: { message: "Integer out of expected range" },
+    6: { message: "Invalid opcode" },
+    7: { message: "Type check error" },
+    8: { message: "Cell overflow" },
+    9: { message: "Cell underflow" },
+    10: { message: "Dictionary error" },
+    11: { message: "'Unknown' error" },
+    12: { message: "Fatal error" },
+    13: { message: "Out of gas error" },
+    14: { message: "Virtualization error" },
+    32: { message: "Action list is invalid" },
+    33: { message: "Action list is too long" },
+    34: { message: "Action is invalid or not supported" },
+    35: { message: "Invalid source address in outbound message" },
+    36: { message: "Invalid destination address in outbound message" },
+    37: { message: "Not enough Toncoin" },
+    38: { message: "Not enough extra currencies" },
+    39: { message: "Outbound message does not fit into a cell after rewriting" },
+    40: { message: "Cannot process a message" },
+    41: { message: "Library reference is null" },
+    42: { message: "Library change action error" },
+    43: { message: "Exceeded maximum number of cells in the library or the maximum depth of the Merkle tree" },
+    50: { message: "Account state size exceeded limits" },
+    128: { message: "Null reference exception" },
+    129: { message: "Invalid serialization prefix" },
+    130: { message: "Invalid incoming message" },
+    131: { message: "Constraints error" },
+    132: { message: "Access denied" },
+    133: { message: "Contract stopped" },
+    134: { message: "Invalid argument" },
+    135: { message: "Code of a contract was not found" },
+    136: { message: "Invalid standard address" },
+    138: { message: "Not a basechain address" },
+    2366: { message: "Incorrect balance after send" },
+    9215: { message: "Incorrect sender" },
+    10363: { message: "Unauthorized burn" },
+    32113: { message: "Insufficient amount of TON attached" },
+    37629: { message: "Insufficient gas for mint" },
+    51950: { message: "Mint is closed" },
+} as const
+
+export const JettonWallet_errors_backward = {
+    "Stack underflow": 2,
+    "Stack overflow": 3,
+    "Integer overflow": 4,
+    "Integer out of expected range": 5,
+    "Invalid opcode": 6,
+    "Type check error": 7,
+    "Cell overflow": 8,
+    "Cell underflow": 9,
+    "Dictionary error": 10,
+    "'Unknown' error": 11,
+    "Fatal error": 12,
+    "Out of gas error": 13,
+    "Virtualization error": 14,
+    "Action list is invalid": 32,
+    "Action list is too long": 33,
+    "Action is invalid or not supported": 34,
+    "Invalid source address in outbound message": 35,
+    "Invalid destination address in outbound message": 36,
+    "Not enough Toncoin": 37,
+    "Not enough extra currencies": 38,
+    "Outbound message does not fit into a cell after rewriting": 39,
+    "Cannot process a message": 40,
+    "Library reference is null": 41,
+    "Library change action error": 42,
+    "Exceeded maximum number of cells in the library or the maximum depth of the Merkle tree": 43,
+    "Account state size exceeded limits": 50,
+    "Null reference exception": 128,
+    "Invalid serialization prefix": 129,
+    "Invalid incoming message": 130,
+    "Constraints error": 131,
+    "Access denied": 132,
+    "Contract stopped": 133,
+    "Invalid argument": 134,
+    "Code of a contract was not found": 135,
+    "Invalid standard address": 136,
+    "Not a basechain address": 138,
+    "Incorrect balance after send": 2366,
+    "Incorrect sender": 9215,
+    "Unauthorized burn": 10363,
+    "Insufficient amount of TON attached": 32113,
+    "Insufficient gas for mint": 37629,
+    "Mint is closed": 51950,
+} as const
+
+const JettonWallet_types: ABIType[] = [
+    {"name":"DataSize","header":null,"fields":[{"name":"cells","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"bits","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"refs","type":{"kind":"simple","type":"int","optional":false,"format":257}}]},
+    {"name":"SignedBundle","header":null,"fields":[{"name":"signature","type":{"kind":"simple","type":"fixed-bytes","optional":false,"format":64}},{"name":"signedData","type":{"kind":"simple","type":"slice","optional":false,"format":"remainder"}}]},
+    {"name":"StateInit","header":null,"fields":[{"name":"code","type":{"kind":"simple","type":"cell","optional":false}},{"name":"data","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"Context","header":null,"fields":[{"name":"bounceable","type":{"kind":"simple","type":"bool","optional":false}},{"name":"sender","type":{"kind":"simple","type":"address","optional":false}},{"name":"value","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"raw","type":{"kind":"simple","type":"slice","optional":false}}]},
+    {"name":"SendParameters","header":null,"fields":[{"name":"mode","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"body","type":{"kind":"simple","type":"cell","optional":true}},{"name":"code","type":{"kind":"simple","type":"cell","optional":true}},{"name":"data","type":{"kind":"simple","type":"cell","optional":true}},{"name":"value","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"to","type":{"kind":"simple","type":"address","optional":false}},{"name":"bounce","type":{"kind":"simple","type":"bool","optional":false}}]},
+    {"name":"MessageParameters","header":null,"fields":[{"name":"mode","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"body","type":{"kind":"simple","type":"cell","optional":true}},{"name":"value","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"to","type":{"kind":"simple","type":"address","optional":false}},{"name":"bounce","type":{"kind":"simple","type":"bool","optional":false}}]},
+    {"name":"DeployParameters","header":null,"fields":[{"name":"mode","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"body","type":{"kind":"simple","type":"cell","optional":true}},{"name":"value","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"bounce","type":{"kind":"simple","type":"bool","optional":false}},{"name":"init","type":{"kind":"simple","type":"StateInit","optional":false}}]},
+    {"name":"StdAddress","header":null,"fields":[{"name":"workchain","type":{"kind":"simple","type":"int","optional":false,"format":8}},{"name":"address","type":{"kind":"simple","type":"uint","optional":false,"format":256}}]},
+    {"name":"VarAddress","header":null,"fields":[{"name":"workchain","type":{"kind":"simple","type":"int","optional":false,"format":32}},{"name":"address","type":{"kind":"simple","type":"slice","optional":false}}]},
+    {"name":"BasechainAddress","header":null,"fields":[{"name":"hash","type":{"kind":"simple","type":"int","optional":true,"format":257}}]},
+    {"name":"JettonWallet$Data","header":null,"fields":[{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"minter","type":{"kind":"simple","type":"address","optional":false}},{"name":"balance","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}}]},
+    {"name":"JettonData","header":null,"fields":[{"name":"totalSupply","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"mintable","type":{"kind":"simple","type":"bool","optional":false}},{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"content","type":{"kind":"simple","type":"cell","optional":false}},{"name":"jettonWalletCode","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"JettonWalletData","header":null,"fields":[{"name":"balance","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"minter","type":{"kind":"simple","type":"address","optional":false}},{"name":"code","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"MaybeAddress","header":null,"fields":[{"name":"address","type":{"kind":"simple","type":"address","optional":true}}]},
+    {"name":"JettonUpdateContent","header":4,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"content","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"JettonTransfer","header":260734629,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"destination","type":{"kind":"simple","type":"address","optional":false}},{"name":"responseDestination","type":{"kind":"simple","type":"address","optional":true}},{"name":"customPayload","type":{"kind":"simple","type":"cell","optional":true}},{"name":"forwardTonAmount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"forwardPayload","type":{"kind":"simple","type":"slice","optional":false,"format":"remainder"}}]},
+    {"name":"JettonTransferInternal","header":395134233,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"sender","type":{"kind":"simple","type":"address","optional":false}},{"name":"responseDestination","type":{"kind":"simple","type":"address","optional":true}},{"name":"forwardTonAmount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"forwardPayload","type":{"kind":"simple","type":"slice","optional":false,"format":"remainder"}}]},
+    {"name":"JettonNotification","header":1935855772,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"sender","type":{"kind":"simple","type":"address","optional":false}},{"name":"forwardPayload","type":{"kind":"simple","type":"slice","optional":false,"format":"remainder"}}]},
+    {"name":"JettonBurn","header":1499400124,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"responseDestination","type":{"kind":"simple","type":"address","optional":true}},{"name":"customPayload","type":{"kind":"simple","type":"cell","optional":true}}]},
+    {"name":"JettonBurnNotification","header":2078119902,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"amount","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"sender","type":{"kind":"simple","type":"address","optional":false}},{"name":"responseDestination","type":{"kind":"simple","type":"address","optional":true}}]},
+    {"name":"JettonExcesses","header":3576854235,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}}]},
+    {"name":"ProvideWalletAddress","header":745978227,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"ownerAddress","type":{"kind":"simple","type":"address","optional":false}},{"name":"includeAddress","type":{"kind":"simple","type":"bool","optional":false}}]},
+    {"name":"TakeWalletAddress","header":3513996288,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"walletAddress","type":{"kind":"simple","type":"address","optional":false}},{"name":"ownerAddress","type":{"kind":"simple","type":"cell","optional":true}}]},
+    {"name":"Mint","header":1680571655,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"receiver","type":{"kind":"simple","type":"address","optional":false}},{"name":"mintMessage","type":{"kind":"simple","type":"JettonTransferInternal","optional":false}}]},
+    {"name":"CloseMinting","header":22,"fields":[]},
+    {"name":"ChangeOwner","header":3,"fields":[{"name":"queryId","type":{"kind":"simple","type":"uint","optional":false,"format":64}},{"name":"newOwner","type":{"kind":"simple","type":"address","optional":false}}]},
+    {"name":"ProvideWalletBalance","header":2059982169,"fields":[{"name":"receiver","type":{"kind":"simple","type":"address","optional":false}},{"name":"includeVerifyInfo","type":{"kind":"simple","type":"bool","optional":false}}]},
+    {"name":"VerifyInfo","header":null,"fields":[{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"minter","type":{"kind":"simple","type":"address","optional":false}},{"name":"code","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"TakeWalletBalance","header":3396861378,"fields":[{"name":"balance","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"verifyInfo","type":{"kind":"simple","type":"VerifyInfo","optional":true}}]},
+    {"name":"ClaimTON","header":60010958,"fields":[{"name":"receiver","type":{"kind":"simple","type":"address","optional":false}}]},
+    {"name":"SliceBitsAndRefs","header":null,"fields":[{"name":"bits","type":{"kind":"simple","type":"int","optional":false,"format":257}},{"name":"refs","type":{"kind":"simple","type":"int","optional":false,"format":257}}]},
+    {"name":"JettonMinterState","header":null,"fields":[{"name":"totalSupply","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"mintable","type":{"kind":"simple","type":"bool","optional":false}},{"name":"adminAddress","type":{"kind":"simple","type":"address","optional":false}},{"name":"jettonContent","type":{"kind":"simple","type":"cell","optional":false}},{"name":"jettonWalletCode","type":{"kind":"simple","type":"cell","optional":false}}]},
+    {"name":"JettonMinter$Data","header":null,"fields":[{"name":"totalSupply","type":{"kind":"simple","type":"uint","optional":false,"format":"coins"}},{"name":"owner","type":{"kind":"simple","type":"address","optional":false}},{"name":"jettonContent","type":{"kind":"simple","type":"cell","optional":false}},{"name":"mintable","type":{"kind":"simple","type":"bool","optional":false}}]},
+]
+
+const JettonWallet_opcodes = {
+    "JettonUpdateContent": 4,
+    "JettonTransfer": 260734629,
+    "JettonTransferInternal": 395134233,
+    "JettonNotification": 1935855772,
+    "JettonBurn": 1499400124,
+    "JettonBurnNotification": 2078119902,
+    "JettonExcesses": 3576854235,
+    "ProvideWalletAddress": 745978227,
+    "TakeWalletAddress": 3513996288,
+    "Mint": 1680571655,
+    "CloseMinting": 22,
+    "ChangeOwner": 3,
+    "ProvideWalletBalance": 2059982169,
+    "TakeWalletBalance": 3396861378,
+    "ClaimTON": 60010958,
+}
+
+const JettonWallet_getters: ABIGetter[] = [
+    {"name":"get_wallet_data","methodId":97026,"arguments":[],"returnType":{"kind":"simple","type":"JettonWalletData","optional":false}},
+]
+
+export const JettonWallet_getterMapping: { [key: string]: string } = {
+    'get_wallet_data': 'getGetWalletData',
+}
+
+const JettonWallet_receivers: ABIReceiver[] = [
+    {"receiver":"internal","message":{"kind":"typed","type":"JettonTransfer"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"JettonTransferInternal"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"ProvideWalletBalance"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"JettonBurn"}},
+    {"receiver":"internal","message":{"kind":"typed","type":"ClaimTON"}},
+]
+
+export const gasForBurn = 6700n;
+export const gasForTransfer = 10500n;
+export const minTonsForStorage = 10000000n;
+export const Basechain = 0n;
+export const walletStateInitCells = 30n;
+export const walletStateInitBits = 20000n;
+
+export class JettonWallet implements Contract {
+    
+    public static readonly storageReserve = 0n;
+    public static readonly errors = JettonWallet_errors_backward;
+    public static readonly opcodes = JettonWallet_opcodes;
+    
+    static async init(owner: Address, minter: Address, balance: bigint) {
+        return await JettonWallet_init(owner, minter, balance);
+    }
+    
+    static async fromInit(owner: Address, minter: Address, balance: bigint) {
+        const __gen_init = await JettonWallet_init(owner, minter, balance);
+        const address = contractAddress(0, __gen_init);
+        return new JettonWallet(address, __gen_init);
+    }
+    
+    static fromAddress(address: Address) {
+        return new JettonWallet(address);
+    }
+    
+    readonly address: Address; 
+    readonly init?: { code: Cell, data: Cell };
+    readonly abi: ContractABI = {
+        types:  JettonWallet_types,
+        getters: JettonWallet_getters,
+        receivers: JettonWallet_receivers,
+        errors: JettonWallet_errors,
+    };
+    
+    constructor(address: Address, init?: { code: Cell, data: Cell }) {
+        this.address = address;
+        this.init = init;
+    }
+    
+    async send(provider: ContractProvider, via: Sender, args: { value: bigint, bounce?: boolean| null | undefined }, message: JettonTransfer | JettonTransferInternal | ProvideWalletBalance | JettonBurn | ClaimTON) {
+        
+        let body: Cell | null = null;
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'JettonTransfer') {
+            body = beginCell().store(storeJettonTransfer(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'JettonTransferInternal') {
+            body = beginCell().store(storeJettonTransferInternal(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'ProvideWalletBalance') {
+            body = beginCell().store(storeProvideWalletBalance(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'JettonBurn') {
+            body = beginCell().store(storeJettonBurn(message)).endCell();
+        }
+        if (message && typeof message === 'object' && !(message instanceof Slice) && message.$$type === 'ClaimTON') {
+            body = beginCell().store(storeClaimTON(message)).endCell();
+        }
+        if (body === null) { throw new Error('Invalid message type'); }
+        
+        await provider.internal(via, { ...args, body: body });
+        
+    }
+    
+    async getGetWalletData(provider: ContractProvider) {
+        const builder = new TupleBuilder();
+        const source = (await provider.get('get_wallet_data', builder.build())).stack;
+        const result = loadGetterTupleJettonWalletData(source);
+        return result;
+    }
+    
+}


### PR DESCRIPTION
This PR introduces the implementation of the tests that simulate interaction of the PoC contract with Launch and Collateral jettons using https://github.com/tact-lang/jetton/.

Currently, we cannot add the Jetton implementation as a dependency, because it is not deployed in npm: https://github.com/tact-lang/jetton/issues/182. So, we have to copy-paste code used in tests.